### PR TITLE
Add kernel patches to fix mmc flash issue with DCS-7060CX-32S

### DIFF
--- a/patch/linux-3.19-mmc-sdhci-Add-a-quirk-for-AMD-SDHC-transfer-mode-reg.patch
+++ b/patch/linux-3.19-mmc-sdhci-Add-a-quirk-for-AMD-SDHC-transfer-mode-reg.patch
@@ -1,0 +1,56 @@
+From 9b8ffea6efb0d0edcac265a1ca422188fc1b6dfb Mon Sep 17 00:00:00 2001
+From: Vincent Wan <vincent.wan@amd.com>
+Date: Wed, 5 Nov 2014 14:09:00 +0800
+Subject: [PATCH] mmc: sdhci: Add a quirk for AMD SDHC transfer mode register
+ need to be cleared for cmd without data
+
+SDHC controller in AMD chipsets require SDHC transfer mode
+register to be cleared for commands without data. The issue was
+uncovered during testing eMMC cards on KB/ML based platforms
+
+Signed-off-by: Vincent Wan <vincent.wan@amd.com>
+Signed-off-by: Wan Zongshun <mcuos.com@gmail.com>
+Signed-off-by: Arindam Nath <arindam.nath@amd.com>
+Tested-by: Vikram B <vikram.b@amd.com>
+Tested-by: Raghavendra Swamy <raghavendra.swamy@amd.com>
+Signed-off-by: Ulf Hansson <ulf.hansson@linaro.org>
+---
+ drivers/mmc/host/sdhci.c  | 9 +++++++--
+ include/linux/mmc/sdhci.h | 2 ++
+ 2 files changed, 9 insertions(+), 2 deletions(-)
+
+Index: linux-3.16/drivers/mmc/host/sdhci.c
+===================================================================
+--- linux-3.16.orig/drivers/mmc/host/sdhci.c
++++ linux-3.16/drivers/mmc/host/sdhci.c
+@@ -891,10 +891,15 @@ static void sdhci_set_transfer_mode(stru
+ 	struct mmc_data *data = cmd->data;
+ 
+ 	if (data == NULL) {
++		if (host->quirks2 &
++			SDHCI_QUIRK2_CLEAR_TRANSFERMODE_REG_BEFORE_CMD) {
++			sdhci_writew(host, 0x0, SDHCI_TRANSFER_MODE);
++		} else {
+ 		/* clear Auto CMD settings for no data CMDs */
+-		mode = sdhci_readw(host, SDHCI_TRANSFER_MODE);
+-		sdhci_writew(host, mode & ~(SDHCI_TRNS_AUTO_CMD12 |
++			mode = sdhci_readw(host, SDHCI_TRANSFER_MODE);
++			sdhci_writew(host, mode & ~(SDHCI_TRNS_AUTO_CMD12 |
+ 				SDHCI_TRNS_AUTO_CMD23), SDHCI_TRANSFER_MODE);
++		}
+ 		return;
+ 	}
+ 
+Index: linux-3.16/include/linux/mmc/sdhci.h
+===================================================================
+--- linux-3.16.orig/include/linux/mmc/sdhci.h
++++ linux-3.16/include/linux/mmc/sdhci.h
+@@ -98,6 +98,8 @@ struct sdhci_host {
+ #define SDHCI_QUIRK2_BROKEN_HS200			(1<<6)
+ /* Controller does not support DDR50 */
+ #define SDHCI_QUIRK2_BROKEN_DDR50			(1<<7)
++/* need clear transfer mode register before send cmd */
++#define SDHCI_QUIRK2_CLEAR_TRANSFERMODE_REG_BEFORE_CMD	(1<<10)
+ 
+ 	int irq;		/* Device IRQ */
+ 	void __iomem *ioaddr;	/* Mapped address */

--- a/patch/linux-3.19-mmc-sdhci-pci-enable-sdhci-doesn-t-support-hs200-qui.patch
+++ b/patch/linux-3.19-mmc-sdhci-pci-enable-sdhci-doesn-t-support-hs200-qui.patch
@@ -1,0 +1,35 @@
+From e765bfa22a8f06f0964a97e3e81148511d75140a Mon Sep 17 00:00:00 2001
+From: Vincent Wan <vincent.wan@amd.com>
+Date: Wed, 5 Nov 2014 14:09:28 +0800
+Subject: [PATCH 3/3] mmc: sdhci-pci: enable sdhci doesn't support hs200 quirk
+ for AMD sdhci
+
+AMD SD controller supports the SDR104 mode, but caps2 can not
+be promoted to support hs200 for eMMC.
+
+Signed-off-by: Vincent Wan <vincent.wan@amd.com>
+Signed-off-by: Wan Zongshun <mcuos.com@gmail.com>
+Signed-off-by: Ulf Hansson <ulf.hansson@linaro.org>
+---
+ drivers/mmc/host/sdhci-pci.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/mmc/host/sdhci-pci.c b/drivers/mmc/host/sdhci-pci.c
+index 5a77f18..c1ecd20 100644
+--- a/drivers/mmc/host/sdhci-pci.c
++++ b/drivers/mmc/host/sdhci-pci.c
+@@ -652,8 +652,10 @@ static int amd_probe(struct sdhci_pci_chip *chip)
+ 	smbus_dev = pci_get_device(PCI_VENDOR_ID_AMD,
+ 			PCI_DEVICE_ID_AMD_HUDSON2_SMBUS, NULL);
+ 
+-	if (smbus_dev && (smbus_dev->revision < 0x51))
++	if (smbus_dev && (smbus_dev->revision < 0x51)) {
+ 		chip->quirks2 |= SDHCI_QUIRK2_CLEAR_TRANSFERMODE_REG_BEFORE_CMD;
++		chip->quirks2 |= SDHCI_QUIRK2_BROKEN_HS200;
++	}
+ 
+ 	return 0;
+ }
+-- 
+2.5.0
+

--- a/patch/linux-3.19-mmc-sdhci-pci-enable-the-clear-transfer-mode-registe.patch
+++ b/patch/linux-3.19-mmc-sdhci-pci-enable-the-clear-transfer-mode-registe.patch
@@ -1,0 +1,64 @@
+From d44f88da42d2a75eeac02f87455043f44e10d7cc Mon Sep 17 00:00:00 2001
+From: Vincent Wan <vincent.wan@amd.com>
+Date: Wed, 5 Nov 2014 14:09:14 +0800
+Subject: [PATCH 2/3] mmc: sdhci-pci: enable the clear transfer mode register
+ quirk for AMD sdhci
+
+This patch is to enable the quirk for AMD sdhci requiring transfer
+mode register need to be cleared for commands without data
+
+Signed-off-by: Vincent Wan <vincent.wan@amd.com>
+Signed-off-by: Wan Zongshun <mcuos.com@gmail.com>
+Signed-off-by: Ulf Hansson <ulf.hansson@linaro.org>
+---
+ drivers/mmc/host/sdhci-pci.c | 27 ++++++++++++++++++++++++++-
+ 1 file changed, 26 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/mmc/host/sdhci-pci.c b/drivers/mmc/host/sdhci-pci.c
+index c25639b..5a77f18 100644
+--- a/drivers/mmc/host/sdhci-pci.c
++++ b/drivers/mmc/host/sdhci-pci.c
+@@ -645,6 +645,23 @@ static const struct sdhci_pci_fixes sdhci_rtsx = {
+ 	.probe_slot	= rtsx_probe_slot,
+ };
+ 
++static int amd_probe(struct sdhci_pci_chip *chip)
++{
++	struct pci_dev	*smbus_dev;
++
++	smbus_dev = pci_get_device(PCI_VENDOR_ID_AMD,
++			PCI_DEVICE_ID_AMD_HUDSON2_SMBUS, NULL);
++
++	if (smbus_dev && (smbus_dev->revision < 0x51))
++		chip->quirks2 |= SDHCI_QUIRK2_CLEAR_TRANSFERMODE_REG_BEFORE_CMD;
++
++	return 0;
++}
++
++static const struct sdhci_pci_fixes sdhci_amd = {
++	.probe		= amd_probe,
++};
++
+ static const struct pci_device_id pci_ids[] = {
+ 	{
+ 		.vendor		= PCI_VENDOR_ID_RICOH,
+@@ -1044,7 +1061,15 @@ static const struct pci_device_id pci_ids[] = {
+ 		.subdevice	= PCI_ANY_ID,
+ 		.driver_data	= (kernel_ulong_t)&sdhci_o2,
+ 	},
+-
++	{
++		.vendor		= PCI_VENDOR_ID_AMD,
++		.device		= PCI_ANY_ID,
++		.class		= PCI_CLASS_SYSTEM_SDHCI << 8,
++		.class_mask	= 0xFFFF00,
++		.subvendor	= PCI_ANY_ID,
++		.subdevice	= PCI_ANY_ID,
++		.driver_data	= (kernel_ulong_t)&sdhci_amd,
++	},
+ 	{	/* Generic SD host controller */
+ 		PCI_DEVICE_CLASS((PCI_CLASS_SYSTEM_SDHCI << 8), 0xFFFF00)
+ 	},
+-- 
+2.5.0
+

--- a/patch/series
+++ b/patch/series
@@ -16,3 +16,6 @@ driver-hwmon-pmbus-ucd9200-mlnx.patch
 driver-arista-piix4-mux-patch.patch
 driver-arista-net-tg3-dma-mask-4g-sb800.patch
 driver-arista-net-tg3-access-regs-indirectly.patch
+linux-3.19-mmc-sdhci-Add-a-quirk-for-AMD-SDHC-transfer-mode-reg.patch
+linux-3.19-mmc-sdhci-pci-enable-the-clear-transfer-mode-registe.patch
+linux-3.19-mmc-sdhci-pci-enable-sdhci-doesn-t-support-hs200-qui.patch


### PR DESCRIPTION
These kernel patches are backport from linux 3.19 to fix mmc issues seen when booting on a DCS-7060CX-32S