### PR TITLE
Add support for PCA954x I2C mux

### DIFF
--- a/patch/config-dell-z9100.patch
+++ b/patch/config-dell-z9100.patch
@@ -1,0 +1,13 @@
+diff --git a/debian/build/build_amd64_none_amd64/.config b/debian/build/build_amd64_none_amd64/.config
+index b22d55f..a57510b 100644
+--- a/debian/build/build_amd64_none_amd64/.config
++++ b/debian/build/build_amd64_none_amd64/.config
+@@ -3146,7 +3146,7 @@ CONFIG_I2C_MUX=m
+ #
+ CONFIG_I2C_MUX_GPIO=m
+ # CONFIG_I2C_MUX_PCA9541 is not set
+-# CONFIG_I2C_MUX_PCA954x is not set
++CONFIG_I2C_MUX_PCA954x=m
+ # CONFIG_I2C_MUX_PINCTRL is not set
+ CONFIG_I2C_HELPER_AUTO=y
+ CONFIG_I2C_SMBUS=m

--- a/patch/series
+++ b/patch/series
@@ -2,6 +2,7 @@
 kernel-sched-core-fix-cgroup-fork-race.patch
 config-dell-s6000.patch
 config-mlnx-sn2700.patch
+config-dell-z9100.patch
 driver-at24-fix-odd-length-two-byte-access.patch
 driver-hwmon-max6620.patch
 driver-hwmon-max6620-fix-rpm-calc.patch


### PR DESCRIPTION
The Dell Z9100 I2C devices are multiplexed behind a series of PCA9547 and PCA9548 muxes. This enables the PCA954x driver support in the kernel to allow access to the System EEPROM and SFP EEPROMs.