### PR TITLE
Add ingrasys switch s9100 kernel patches

### DIFF
--- a/patch/config-ingrasys-s9100.patch
+++ b/patch/config-ingrasys-s9100.patch
@@ -1,0 +1,44 @@
+Enable CONFIG_I2C_MUX_PCA954x, CONFIG_I2C_MUX_PCA954X_DESELECT_ON_EXIT,
+       CONFIG_GPIO_PCA953X, CONFIG_I2C_GPIO
+
+From: wadelnn <wadelnn@users.noreply.github.com>
+
+
+
+---
+ debian/build/build_amd64_none_amd64/.config | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/debian/build/build_amd64_none_amd64/.config b/debian/build/build_amd64_none_amd64/.config
+index a57510b..3cde51e 100644
+--- a/debian/build/build_amd64_none_amd64/.config
++++ b/debian/build/build_amd64_none_amd64/.config
+@@ -3147,6 +3147,7 @@ CONFIG_I2C_MUX=m
+ CONFIG_I2C_MUX_GPIO=m
+ # CONFIG_I2C_MUX_PCA9541 is not set
+ CONFIG_I2C_MUX_PCA954x=m
++CONFIG_I2C_MUX_PCA954X_DESELECT_ON_EXIT=y
+ # CONFIG_I2C_MUX_PINCTRL is not set
+ CONFIG_I2C_HELPER_AUTO=y
+ CONFIG_I2C_SMBUS=m
+@@ -3190,7 +3191,7 @@ CONFIG_I2C_SCMI=m
+ CONFIG_I2C_DESIGNWARE_CORE=m
+ CONFIG_I2C_DESIGNWARE_PLATFORM=m
+ CONFIG_I2C_DESIGNWARE_PCI=m
+-# CONFIG_I2C_GPIO is not set
++CONFIG_I2C_GPIO=m
+ CONFIG_I2C_KEMPLD=m
+ CONFIG_I2C_OCORES=m
+ CONFIG_I2C_PCA_PLATFORM=m
+@@ -3304,7 +3305,7 @@ CONFIG_GPIO_SCH=m
+ #
+ # CONFIG_GPIO_MAX7300 is not set
+ # CONFIG_GPIO_MAX732X is not set
+-# CONFIG_GPIO_PCA953X is not set
++CONFIG_GPIO_PCA953X=m
+ # CONFIG_GPIO_PCF857X is not set
+ # CONFIG_GPIO_ADP5588 is not set
+ 
+-- 
+2.1.4
+

--- a/patch/driver-pca954x-i2c-mux-deselect-on-exit-config-option.patch
+++ b/patch/driver-pca954x-i2c-mux-deselect-on-exit-config-option.patch
@@ -1,0 +1,62 @@
+Adding PCA9548 I2C MUX deselect on exit config
+
+From: wadelnn <wadelnn@users.noreply.github.com>
+
+---
+ drivers/i2c/muxes/Kconfig           | 7 +++++++
+ drivers/i2c/muxes/i2c-mux-pca954x.c | 7 ++++++-
+ 2 files changed, 13 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/i2c/muxes/Kconfig b/drivers/i2c/muxes/Kconfig
+index f6d313e..83a49d3 100644
+--- a/drivers/i2c/muxes/Kconfig
++++ b/drivers/i2c/muxes/Kconfig
+@@ -48,6 +48,13 @@ config I2C_MUX_PCA954x
+ 	  This driver can also be built as a module.  If so, the module
+ 	  will be called i2c-mux-pca954x.
+ 
++config I2C_MUX_PCA954X_DESELECT_ON_EXIT
++	bool "Enable deselect-on-exit feature for PCA954X devices."
++	depends on I2C_MUX_PCA954x
++	help
++	  If you say yes here you enable the deselect-on-exit feature in
++	  the pca954x i2c driver.
++
+ config I2C_MUX_PINCTRL
+ 	tristate "pinctrl-based I2C multiplexer"
+ 	depends on PINCTRL
+diff --git a/drivers/i2c/muxes/i2c-mux-pca954x.c b/drivers/i2c/muxes/i2c-mux-pca954x.c
+index 9bd4212..07ad443 100644
+--- a/drivers/i2c/muxes/i2c-mux-pca954x.c
++++ b/drivers/i2c/muxes/i2c-mux-pca954x.c
+@@ -188,6 +188,7 @@ static int pca954x_probe(struct i2c_client *client,
+ 	struct gpio_desc *gpio;
+ 	int num, force, class;
+ 	struct pca954x *data;
++    int deselect_on_exit = 0;
+ 	int ret;
+ 
+ 	if (!i2c_check_functionality(adap, I2C_FUNC_SMBUS_BYTE))
+@@ -213,6 +214,10 @@ static int pca954x_probe(struct i2c_client *client,
+ 		return -ENODEV;
+ 	}
+ 
++#ifdef CONFIG_I2C_MUX_PCA954X_DESELECT_ON_EXIT
++    deselect_on_exit = 1;
++#endif
++
+ 	data->type = id->driver_data;
+ 	data->last_chan = 0;		   /* force the first selection */
+ 
+@@ -233,7 +238,7 @@ static int pca954x_probe(struct i2c_client *client,
+ 		data->virt_adaps[num] =
+ 			i2c_add_mux_adapter(adap, &client->dev, client,
+ 				force, num, class, pca954x_select_chan,
+-				(pdata && pdata->modes[num].deselect_on_exit)
++				(pdata && pdata->modes[num].deselect_on_exit) || deselect_on_exit
+ 					? pca954x_deselect_mux : NULL);
+ 
+ 		if (data->virt_adaps[num] == NULL) {
+-- 
+2.1.4
+

--- a/patch/series
+++ b/patch/series
@@ -3,6 +3,7 @@ kernel-sched-core-fix-cgroup-fork-race.patch
 config-dell-s6000.patch
 config-mlnx-sn2700.patch
 config-dell-z9100.patch
+config-ingrasys-s9100.patch
 driver-at24-fix-odd-length-two-byte-access.patch
 driver-hwmon-max6620.patch
 driver-hwmon-max6620-fix-rpm-calc.patch
@@ -17,6 +18,7 @@ driver-hwmon-pmbus-ucd9200-mlnx.patch
 driver-arista-piix4-mux-patch.patch
 driver-arista-net-tg3-dma-mask-4g-sb800.patch
 driver-arista-net-tg3-access-regs-indirectly.patch
+driver-pca954x-i2c-mux-deselect-on-exit-config-option.patch
 linux-3.19-mmc-sdhci-Add-a-quirk-for-AMD-SDHC-transfer-mode-reg.patch
 linux-3.19-mmc-sdhci-pci-enable-the-clear-transfer-mode-registe.patch
 linux-3.19-mmc-sdhci-pci-enable-sdhci-doesn-t-support-hs200-qui.patch


### PR DESCRIPTION
* Add ingrasys s9100 kernel config
* Add PCA954x I2C deselect on exit config option

This feature use deselect_on_exit flag to avoid i2c command failed. The pdata->modes[num].deselect_on_exit is different transaction flag from dev_get_platdata. If other platforms use pca954x module frequently may cause this issue. We want to make sure that the pca954x channel register is set everytime to pca954x_select_chan function in i2c-mux-pca954x.c.

Signed-off-by: Wade He <chihen.he@gmail.com>