### PR TITLE
Add support for LM75B

### DIFF
--- a/patch/driver-hwmon-lm75b-update.patch
+++ b/patch/driver-hwmon-lm75b-update.patch
@@ -1,0 +1,44 @@
+From 7e24a7bf79b4ae6c12cd3306f0340883b6b0fd73 Mon Sep 17 00:00:00 2001
+From: Abhisit Sangjan <asang@celestica.com>
+Date: Fri, 30 Jun 2017 10:13:12 +0700
+Subject: [PATCH] hwmon: Update to support lm75b
+
+* Add lm75b
+---
+ drivers/hwmon/lm75.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/drivers/hwmon/lm75.c b/drivers/hwmon/lm75.c
+index 479ffbe..38b6f8f 100644
+--- a/drivers/hwmon/lm75.c
++++ b/drivers/hwmon/lm75.c
+@@ -44,6 +44,7 @@ enum lm75_type {		/* keep sorted in alphabetical order */
+ 	g751,
+ 	lm75,
+ 	lm75a,
++	lm75b,
+ 	max6625,
+ 	max6626,
+ 	mcp980x,
+@@ -232,6 +233,10 @@ lm75_probe(struct i2c_client *client, const struct i2c_device_id *id)
+ 		data->resolution = 9;
+ 		data->sample_time = HZ / 2;
+ 		break;
++	case lm75b:
++		data->resolution = 11;
++		data->sample_time = HZ / 4;
++		break;
+ 	case max6625:
+ 		data->resolution = 9;
+ 		data->sample_time = HZ / 4;
+@@ -315,6 +320,7 @@ static const struct i2c_device_id lm75_ids[] = {
+ 	{ "g751", g751, },
+ 	{ "lm75", lm75, },
+ 	{ "lm75a", lm75a, },
++	{ "lm75b", lm75b, },
+ 	{ "max6625", max6625, },
+ 	{ "max6626", max6626, },
+ 	{ "mcp980x", mcp980x, },
+-- 
+1.9.1
+

--- a/patch/series
+++ b/patch/series
@@ -8,6 +8,7 @@ driver-at24-fix-odd-length-two-byte-access.patch
 driver-hwmon-max6620.patch
 driver-hwmon-max6620-fix-rpm-calc.patch
 driver-hwmon-max6620-update.patch
+driver-hwmon-lm75b-update.patch
 driver-hwmon-pmbus-dni_dps460.patch
 driver-hwmon-pmbus-dni_dps460-update-pmbus-core.patch
 driver-i2c-bus-intel-ismt-add-delay-param.patch


### PR DESCRIPTION
I am using LM75B on my platform, name Seastone. I would like to put LM75B to the Kernel.
I am disabled file operation detect() and address_list(), since It wrong found 100+ of LM75B sensors on my machine and I would like to manual probe() by echo.