### PR TITLE
rtnetlink: catch -EOPNOTSUPP errors from ndo_bridge_getlink

### DIFF
--- a/patch/rtnetlink-catch-EOPNOTSUPP-errors.patch
+++ b/patch/rtnetlink-catch-EOPNOTSUPP-errors.patch
@@ -1,0 +1,50 @@
+commit 10c9f8f890dcff762b74fc71aaac6402aa1660c9
+Author: Jipan Yang <jipan.yang@alibaba-inc.com>
+Date:   Tue Jun 13 16:36:16 2017 -0700
+
+    rtnetlink: catch -EOPNOTSUPP errors from ndo_bridge_getlink
+    https://github.com/torvalds/linux/commit/d64f69b0373a7d0bcec8b5da7712977518a8f42b
+
+diff --git a/net/core/rtnetlink.c b/net/core/rtnetlink.c
+index e4666af..a7e13b5 100644
+--- a/net/core/rtnetlink.c
++++ b/net/core/rtnetlink.c
+@@ -2623,6 +2623,7 @@ static int rtnl_bridge_getlink(struct sk_buff *skb, struct netlink_callback *cb)
+ 	u32 seq = cb->nlh->nlmsg_seq;
+ 	struct nlattr *extfilt;
+ 	u32 filter_mask = 0;
++	int err;
+ 
+ 	extfilt = nlmsg_find_attr(cb->nlh, sizeof(struct ifinfomsg),
+ 				  IFLA_EXT_MASK);
+@@ -2635,18 +2636,22 @@ static int rtnl_bridge_getlink(struct sk_buff *skb, struct netlink_callback *cb)
+ 		struct net_device *br_dev = netdev_master_upper_dev_get(dev);
+ 
+ 		if (br_dev && br_dev->netdev_ops->ndo_bridge_getlink) {
+-			if (idx >= cb->args[0] &&
+-			    br_dev->netdev_ops->ndo_bridge_getlink(
+-				    skb, portid, seq, dev, filter_mask) < 0)
+-				break;
++			if (idx >= cb->args[0]) {
++			    err = br_dev->netdev_ops->ndo_bridge_getlink(
++				    skb, portid, seq, dev, filter_mask);
++			    if (err < 0 && err != -EOPNOTSUPP)
++				    break;
++			}
+ 			idx++;
+ 		}
+ 
+ 		if (ops->ndo_bridge_getlink) {
+-			if (idx >= cb->args[0] &&
+-			    ops->ndo_bridge_getlink(skb, portid, seq, dev,
+-						    filter_mask) < 0)
+-				break;
++			if (idx >= cb->args[0]) {
++			    err = ops->ndo_bridge_getlink(skb, portid, seq, dev,
++						    filter_mask);
++			    if (err < 0 && err != -EOPNOTSUPP)
++				    break;
++			}
+ 			idx++;
+ 		}
+ 	}

--- a/patch/series
+++ b/patch/series
@@ -23,3 +23,4 @@ driver-pca954x-i2c-mux-force-deselect-on-exit-flag.patch
 linux-3.19-mmc-sdhci-Add-a-quirk-for-AMD-SDHC-transfer-mode-reg.patch
 linux-3.19-mmc-sdhci-pci-enable-the-clear-transfer-mode-registe.patch
 linux-3.19-mmc-sdhci-pci-enable-sdhci-doesn-t-support-hs200-qui.patch
+rtnetlink-catch-EOPNOTSUPP-errors.patch


### PR DESCRIPTION
To fix "bridge vlan show" empty result issue.

On platform which has Intel I354 nic as management port,   I354 is capable of SR-IOV,  IGB driver registered igb_ndo_bridge_getlink() and it would be called in rtnl_bridge_getlink().  But SR-IOV is not enabled by default,  igb_ndo_bridge_getlink() returns -EOPNOTSUPP which would cause rtnl_bridge_getlink() to abort the processing and returns empty or partial result to bridge vlan request 