### PR TITLE
Disallow resetting to the default mac after kexec

### DIFF
--- a/patch/driver-arista-net-tg3-disallow-broadcom-default-mac.patch
+++ b/patch/driver-arista-net-tg3-disallow-broadcom-default-mac.patch
@@ -1,0 +1,75 @@
+For Arista platforms, after calling kexec in fast-reboot, the MAC address
+of management interface is reset to 00:10:18:00:00:00. This patch can recover
+the MAC with the one previously saved by Arista Aboot.
+
+Index: linux-3.16/drivers/net/ethernet/broadcom/tg3.c
+===================================================================
+--- linux-3.16.orig/drivers/net/ethernet/broadcom/tg3.c
++++ linux-3.16/drivers/net/ethernet/broadcom/tg3.c
+@@ -9329,6 +9329,15 @@ static int tg3_halt(struct tg3 *tp, int 
+ 	return err;
+ }
+ 
++static inline int is_valid_bcm_ether_addr(const u8 *addr)
++{
++	if (!is_valid_ether_addr(addr))
++		return 0;
++	/* Disallow Broadcom default MAC 00:10:18:00:00:00 to avoid conflicts */
++	return (addr[0] || addr[1] != 0x10 || addr[2] != 0x18 ||
++		addr[3] || addr[4] || addr[5]);
++}
++
+ static int tg3_set_mac_addr(struct net_device *dev, void *p)
+ {
+ 	struct tg3 *tp = netdev_priv(dev);
+@@ -9336,7 +9345,7 @@ static int tg3_set_mac_addr(struct net_d
+ 	int err = 0;
+ 	bool skip_mac_1 = false;
+ 
+-	if (!is_valid_ether_addr(addr->sa_data))
++	if (!is_valid_bcm_ether_addr(addr->sa_data))
+ 		return -EADDRNOTAVAIL;
+ 
+ 	memcpy(dev->dev_addr, addr->sa_data, dev->addr_len);
+@@ -16990,31 +16999,21 @@ static int tg3_get_device_address(struct
+ 		dev->dev_addr[5] = (lo >>  0) & 0xff;
+ 
+ 		/* Some old bootcode may report a 0 MAC address in SRAM */
+-		addr_ok = is_valid_ether_addr(&dev->dev_addr[0]);
++		addr_ok = is_valid_bcm_ether_addr(&dev->dev_addr[0]);
+ 	}
+ 	if (!addr_ok) {
+-		/* Next, try NVRAM. */
+-		if (!tg3_flag(tp, NO_NVRAM) &&
+-		    !tg3_nvram_read_be32(tp, mac_offset + 0, &hi) &&
+-		    !tg3_nvram_read_be32(tp, mac_offset + 4, &lo)) {
+-			memcpy(&dev->dev_addr[0], ((char *)&hi) + 2, 2);
+-			memcpy(&dev->dev_addr[2], (char *)&lo, sizeof(lo));
+-		}
+-		/* Finally just fetch it out of the MAC control regs. */
+-		else {
+-			hi = tr32(MAC_ADDR_0_HIGH);
+-			lo = tr32(MAC_ADDR_0_LOW);
++		hi = tr32(MAC_ADDR_0_HIGH);
++		lo = tr32(MAC_ADDR_0_LOW);
+ 
+-			dev->dev_addr[5] = lo & 0xff;
+-			dev->dev_addr[4] = (lo >> 8) & 0xff;
+-			dev->dev_addr[3] = (lo >> 16) & 0xff;
+-			dev->dev_addr[2] = (lo >> 24) & 0xff;
+-			dev->dev_addr[1] = hi & 0xff;
+-			dev->dev_addr[0] = (hi >> 8) & 0xff;
+-		}
++		dev->dev_addr[5] = lo & 0xff;
++		dev->dev_addr[4] = (lo >> 8) & 0xff;
++		dev->dev_addr[3] = (lo >> 16) & 0xff;
++		dev->dev_addr[2] = (lo >> 24) & 0xff;
++		dev->dev_addr[1] = hi & 0xff;
++		dev->dev_addr[0] = (hi >> 8) & 0xff;
+ 	}
+ 
+-	if (!is_valid_ether_addr(&dev->dev_addr[0])) {
++	if (!is_valid_bcm_ether_addr(&dev->dev_addr[0])) {
+ #ifdef CONFIG_SPARC
+ 		if (!tg3_get_default_macaddr_sparc(tp))
+ 			return 0;

--- a/patch/series
+++ b/patch/series
@@ -19,6 +19,7 @@ driver-hwmon-pmbus-ucd9200-mlnx.patch
 driver-arista-piix4-mux-patch.patch
 driver-arista-net-tg3-dma-mask-4g-sb800.patch
 driver-arista-net-tg3-access-regs-indirectly.patch
+driver-arista-net-tg3-disallow-broadcom-default-mac.patch
 driver-pca954x-i2c-mux-force-deselect-on-exit-flag.patch
 linux-3.19-mmc-sdhci-Add-a-quirk-for-AMD-SDHC-transfer-mode-reg.patch
 linux-3.19-mmc-sdhci-pci-enable-the-clear-transfer-mode-registe.patch


### PR DESCRIPTION
For Arista platforms, after calling kexec in fast-reboot, the MAC address of management interface is reset to 00:10:18:00:00:00. This patch can recover the MAC with the one previously saved by Arista Aboot.