### PR TITLE
Relax the disallowing of broadcom-default MAC in two cases

### DIFF
--- a/patch/driver-arista-net-tg3-disallow-broadcom-default-mac.patch
+++ b/patch/driver-arista-net-tg3-disallow-broadcom-default-mac.patch
@@ -2,11 +2,11 @@ For Arista platforms, after calling kexec in fast-reboot, the MAC address
 of management interface is reset to 00:10:18:00:00:00. This patch can recover
 the MAC with the one previously saved by Arista Aboot.
 
-Index: linux-3.16/drivers/net/ethernet/broadcom/tg3.c
-===================================================================
---- linux-3.16.orig/drivers/net/ethernet/broadcom/tg3.c
-+++ linux-3.16/drivers/net/ethernet/broadcom/tg3.c
-@@ -9329,6 +9329,15 @@ static int tg3_halt(struct tg3 *tp, int 
+diff --git a/drivers/net/ethernet/broadcom/tg3.c b/drivers/net/ethernet/broadcom/tg3.c
+index 3f3d205..13b513d 100644
+--- a/drivers/net/ethernet/broadcom/tg3.c
++++ b/drivers/net/ethernet/broadcom/tg3.c
+@@ -9340,6 +9340,15 @@ static int tg3_halt(struct tg3 *tp, int kind, bool silent)
  	return err;
  }
  
@@ -22,16 +22,7 @@ Index: linux-3.16/drivers/net/ethernet/broadcom/tg3.c
  static int tg3_set_mac_addr(struct net_device *dev, void *p)
  {
  	struct tg3 *tp = netdev_priv(dev);
-@@ -9336,7 +9345,7 @@ static int tg3_set_mac_addr(struct net_d
- 	int err = 0;
- 	bool skip_mac_1 = false;
- 
--	if (!is_valid_ether_addr(addr->sa_data))
-+	if (!is_valid_bcm_ether_addr(addr->sa_data))
- 		return -EADDRNOTAVAIL;
- 
- 	memcpy(dev->dev_addr, addr->sa_data, dev->addr_len);
-@@ -16990,31 +16999,21 @@ static int tg3_get_device_address(struct
+@@ -16974,28 +16983,18 @@ static int tg3_get_device_address(struct tg3 *tp)
  		dev->dev_addr[5] = (lo >>  0) & 0xff;
  
  		/* Some old bootcode may report a 0 MAC address in SRAM */
@@ -68,8 +59,4 @@ Index: linux-3.16/drivers/net/ethernet/broadcom/tg3.c
 +		dev->dev_addr[0] = (hi >> 8) & 0xff;
  	}
  
--	if (!is_valid_ether_addr(&dev->dev_addr[0])) {
-+	if (!is_valid_bcm_ether_addr(&dev->dev_addr[0])) {
- #ifdef CONFIG_SPARC
- 		if (!tg3_get_default_macaddr_sparc(tp))
- 			return 0;
+ 	if (!is_valid_ether_addr(&dev->dev_addr[0])) {


### PR DESCRIPTION
We once submitted a kernel patch to fix a MAC issue in fast-rebooting by disallowing the broadcom-default MAC. In case of any special situation that 00:10:18:00:00:00 is still needed, we provide this change to relax the disallowing in two cases: 1) the MAC of an interface will be able to be changed to 00:10:18:00:00:00 by "ip link set eth0 address 00:10:18:00:00:00", which was not in our previous change; 2) an interface only having 00:10:18:00:00:00 in its register will be able to be initialized and shown in "ip addr", which was not in our previous change. 