### PR TITLE
Add MAX6697 kernel module for Arista 7060CX-32S

### DIFF
--- a/patch/config-arista-7060-cx32s.patch
+++ b/patch/config-arista-7060-cx32s.patch
@@ -1,0 +1,13 @@
+diff --git a/debian/build/build_amd64_none_amd64/.config b/debian/build/build_amd64_none_amd64/.config
+index 6b6aea9..e0a959c 100644
+--- a/debian/build/build_amd64_none_amd64/.config
++++ b/debian/build/build_amd64_none_amd64/.config
+@@ -3455,7 +3455,7 @@ CONFIG_SENSORS_MAX6639=m
+ CONFIG_SENSORS_MAX6642=m
+ CONFIG_SENSORS_MAX6650=m
+ CONFIG_SENSORS_MAX6620=m
+-# CONFIG_SENSORS_MAX6697 is not set
++CONFIG_SENSORS_MAX6697=m
+ # CONFIG_SENSORS_HTU21 is not set
+ # CONFIG_SENSORS_MCP3021 is not set
+ CONFIG_SENSORS_ADCXX=m

--- a/patch/series
+++ b/patch/series
@@ -4,6 +4,7 @@ config-dell-s6000.patch
 config-mlnx-sn2700.patch
 config-dell-z9100.patch
 config-ingrasys-s9100.patch
+config-arista-7060-cx32s.patch
 driver-at24-fix-odd-length-two-byte-access.patch
 driver-hwmon-max6620.patch
 driver-hwmon-max6620-fix-rpm-calc.patch


### PR DESCRIPTION
Add the MAX6697 kernel module to the build to allow for the temperature sensor to be used on the Arista 7060CX-32S.

You can verify that the MAX6697 kernel module exists with the command below:
$ find /lib/modules/$(uname -r) | grep max6697