### PR TITLE
Disable suspend functionality

### DIFF
--- a/patch/config-disable-suspend.patch
+++ b/patch/config-disable-suspend.patch
@@ -1,0 +1,13 @@
+diff --git a/debian/build/build_amd64_none_amd64/.config b/debian/build/build_amd64_none_amd64/.config
+index 4efabb8..587cef3 100644
+--- a/debian/build/build_amd64_none_amd64/.config
++++ b/debian/build/build_amd64_none_amd64/.config
+@@ -546,7 +546,7 @@ CONFIG_USE_PERCPU_NUMA_NODE_ID=y
+ # Power management and ACPI options
+ #
+ CONFIG_ARCH_HIBERNATION_HEADER=y
+-CONFIG_SUSPEND=y
++# CONFIG_SUSPEND is not set
+ CONFIG_SUSPEND_FREEZER=y
+ CONFIG_HIBERNATE_CALLBACKS=y
+ CONFIG_HIBERNATION=y

--- a/patch/series
+++ b/patch/series
@@ -1,5 +1,6 @@
 # This series applies on GIT commit 1451b36b2b0d62178e42f648d8a18131af18f7d8
 kernel-sched-core-fix-cgroup-fork-race.patch
+config-disable-suspend.patch
 config-dell-s6000.patch
 config-mlnx-sn2700.patch
 config-dell-z9100.patch


### PR DESCRIPTION
Otherwise some devices could be suspended and then woke up with different names.