### PR TITLE
[Kernel] support downloading built kernel Debian packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,38 @@
 .ONESHELL:
 SHELL = /bin/bash
 
+ifneq ($(kernel_build_method), "build")
+# Downloading kernel
+
+LINUX_HEADER_COMMON = linux-headers-3.16.0-5-common_3.16.51-3+deb8u1_amd64.deb
+LINUX_HEADER_COMMON_URL = "https://sonicstorage.blob.core.windows.net/packages/kernel-public/linux-headers-3.16.0-5-common_3.16.51-3+deb8u1_amd64.deb?sv=2015-04-05&sr=b&sig=t3zPXXWP%2BDOVBRAYeFfobX%2FWtxQRSS9QTWWJZVU3PQg%3D&se=2032-03-08T02%3A59%3A37Z&sp=r"
+
+LINUX_HEADER_AMD64 = linux-headers-3.16.0-5-amd64_3.16.51-3+deb8u1_amd64.deb
+LINUX_HEADER_AMD64_URL = "https://sonicstorage.blob.core.windows.net/packages/kernel-public/linux-headers-3.16.0-5-amd64_3.16.51-3+deb8u1_amd64.deb?sv=2015-04-05&sr=b&sig=9%2FeG5iU%2BKhpFVjwQ379eLz7MdL%2FjuKKdbyWalFINO1A%3D&se=2032-03-10T15%3A35%3A57Z&sp=r"
+
+LINUX_IMAGE = linux-image-3.16.0-5-amd64_3.16.51-3+deb8u1_amd64.deb
+LINUX_IMAGE_URL = "https://sonicstorage.blob.core.windows.net/packages/kernel-public/linux-image-3.16.0-5-amd64_3.16.51-3+deb8u1_amd64.deb?sv=2015-04-05&sr=b&sig=ySooXCR1xEr1nUeJqV2r9QiBA3RwcxyundWCVtpIYWk%3D&se=2032-03-08T03%3A01%3A22Z&sp=r"
+
+MAIN_TARGET = linux-headers-3.16.0-5-common_3.16.51-3+deb8u1_amd64.deb
+DERIVED_TARGETS = linux-headers-3.16.0-5-amd64_3.16.51-3+deb8u1_amd64.deb \
+                  linux-image-3.16.0-5-amd64_3.16.51-3+deb8u1_amd64.deb
+
+$(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
+	# Obtaining the Debian kernel packages
+	rm -rf $(BUILD_DIR)
+	wget -O $(LINUX_HEADER_COMMON) $(LINUX_HEADER_COMMON_URL)
+	wget -O $(LINUX_HEADER_AMD64) $(LINUX_HEADER_AMD64_URL)
+	wget -O $(LINUX_IMAGE) $(LINUX_IMAGE_URL)
+
+ifneq ($(DEST),)
+	mv $(DERIVED_TARGETS) $* $(DEST)/
+endif
+
+$(addprefix $(DEST)/, $(DERIVED_TARGETS)): $(DEST)/% : $(DEST)/$(MAIN_TARGET)
+
+else
+# Building kernel
+
 KVERSION_SHORT ?= 3.16.0-5
 KVERSION ?= $(KVERSION_SHORT)-amd64
 KERNEL_VERSION ?= 3.16.51
@@ -57,3 +89,5 @@ ifneq ($(DEST),)
 endif
 
 $(addprefix $(DEST)/, $(DERIVED_TARGETS)): $(DEST)/% : $(DEST)/$(MAIN_TARGET)
+
+endif # building kernel

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .ONESHELL:
 SHELL = /bin/bash
 
-ifneq ($(kernel_build_method), "build")
+ifneq ($(kernel_procure_method), "build")
 # Downloading kernel
 
 LINUX_HEADER_COMMON = linux-headers-3.16.0-5-common_3.16.51-3+deb8u1_amd64.deb


### PR DESCRIPTION
Add support to download pre-built Linux kernel Debian packages instead of building from source files.

This change prefers the method of download over build.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

Note: this PR is better go in after https://github.com/Azure/sonic-buildimage/pull/1837 but it doesn't have to.