### PR TITLE
Upgrade kernel to debian 4.9.110-3+deb9u2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ SHELL = /bin/bash
 KVERSION_SHORT ?= 4.9.0-7
 KVERSION ?= $(KVERSION_SHORT)-amd64
 KERNEL_VERSION ?= 4.9.110
-KERNEL_SUBVERSION ?= 3+deb9u1
+KERNEL_SUBVERSION ?= 3+deb9u2
 kernel_procure_method ?= build
 
 LINUX_HEADER_COMMON = linux-headers-$(KVERSION_SHORT)-common_$(KERNEL_VERSION)-$(KERNEL_SUBVERSION)_all.deb

--- a/Makefile
+++ b/Makefile
@@ -18,11 +18,11 @@ DERIVED_TARGETS = $(LINUX_HEADER_AMD64) $(LINUX_IMAGE)
 ifneq ($(kernel_procure_method), build)
 # Downloading kernel
 
-LINUX_HEADER_COMMON_URL = "https://sonicstorage.blob.core.windows.net/packages/kernel-public/linux-headers-4.9.0-7-common_4.9.110-3+deb9u1_all.deb?sv=2015-04-05&sr=b&sig=1%2FgRlKSoUnmnuwBoylk2Scn9lGxQMksXjLGTsNnl4pk%3D&se=2155-07-06T08%3A50%3A06Z&sp=r"
+LINUX_HEADER_COMMON_URL = "https://sonicstorage.blob.core.windows.net/packages/kernel-public/linux-headers-4.9.0-7-common_4.9.110-3+deb9u2_all.deb?sv=2015-04-05&sr=b&sig=LlKqKecY6MDSwFMTxpKErh7FX1Lrvse2yVt3niYnhds%3D&se=2128-02-24T04%3A47%3A48Z&sp=r"
 
-LINUX_HEADER_AMD64_URL = "https://sonicstorage.blob.core.windows.net/packages/kernel-public/linux-headers-4.9.0-7-amd64_4.9.110-3+deb9u1_amd64.deb?sv=2015-04-05&sr=b&sig=3JlLD0%2FXIuv5MYmi8UAlsCyzNbKbIkilo1c1JJtIimM%3D&se=2155-07-06T08%3A51%3A34Z&sp=r"
+LINUX_HEADER_AMD64_URL = "https://sonicstorage.blob.core.windows.net/packages/kernel-public/linux-headers-4.9.0-7-amd64_4.9.110-3+deb9u2_amd64.deb?sv=2015-04-05&sr=b&sig=SfQLjiBPPMcRUOmBPvXq2%2F6SsW3ul9%2FlaROplXdGij0%3D&se=2128-02-24T04%3A48%3A38Z&sp=r"
 
-LINUX_IMAGE_URL = "https://sonicstorage.blob.core.windows.net/packages/kernel-public/linux-image-4.9.0-7-amd64_4.9.110-3+deb9u1_amd64.deb?sv=2015-04-05&sr=b&sig=D5SXjaNrVCOkkwyeq2Wye%2BHSR86I3cFJEzVFOxJwPC0%3D&se=2155-07-06T08%3A50%3A58Z&sp=r"
+LINUX_IMAGE_URL = "https://sonicstorage.blob.core.windows.net/packages/kernel-public/linux-image-4.9.0-7-amd64_4.9.110-3+deb9u2_amd64.deb?sv=2015-04-05&sr=b&sig=PNKGpLjELZem0IacUMM1jU%2Ft5ujoVvUb9JzxrUhE1Wk%3D&se=2128-02-24T04%3A48%3A57Z&sp=r"
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	# Obtaining the Debian kernel packages

--- a/patch/preconfig/changelog.patch
+++ b/patch/preconfig/changelog.patch
@@ -14,18 +14,18 @@ index 026b840..88c8a43 100644
 --- a/debian/changelog
 +++ b/debian/changelog
 @@ -1,3 +1,15 @@
-+linux (4.9.110-3+deb9u1) sonic; urgency=high
++linux (4.9.110-3+deb9u2) sonic; urgency=high
 +
 +  * add driver patches for MLNX SN2700
 +
 + -- Guohan Lu <gulv@microsoft.com>  Sun, 19 Dec 2015 01:50:04 +0100
 +
-+linux (4.9.110-3+deb9u1) sonic; urgency=high
++linux (4.9.110-3+deb9u2) sonic; urgency=high
 +
 +  * add support for S6000
 +
 + -- Shuotian Cheng <shuche@microsoft.com>  Sun, 19 Dec 2015 01:50:04 +0100
 +
- linux (4.9.110-3+deb9u1) stretch-security; urgency=high
+ linux (4.9.110-3+deb9u2) stretch-security; urgency=high
  
-   [ Romain Perier ]
+   * Revert "net: increase fragment memory usage limits"


### PR DESCRIPTION
To fix security issue https://security-tracker.debian.org/tracker/CVE-2018-5391
TODO:

1. ~~check PR build, and upload to sonicstorage for downloading~~ Done https://sonic-jenkins.westus2.cloudapp.azure.com/job/common/job/linux-kernel-pr-build/93/
2. merge this PR
3. update sonic-buildimage/rules/linux-kernel.mk
