### PR TITLE
import upstream optoe chunk offset fix

### DIFF
--- a/patch/driver-support-optoe-chunk-offset-fix.patch
+++ b/patch/driver-support-optoe-chunk-offset-fix.patch
@@ -1,0 +1,67 @@
+From e317fa8a47a3718d21edc9b66a7126b021b8ee6e Mon Sep 17 00:00:00 2001
+
+From: Don Bollinger <don@thebollingers.org>
+
+Subject: [PATCH] Correct a panic inducing defect which is triggered on a read
+ (or write) which begins beyond byte 128, on a byte which is not aligned on a
+ 128 byte chunk boundary, and which crosses a chunk boundary.
+---
+ drivers/misc/eeprom/optoe.c |   27 ++++++++++++++-------------
+ 1 file changed, 14 insertions(+), 13 deletions(-)
+
+diff --git a/drivers/misc/eeprom/optoe.c b/drivers/misc/eeprom/optoe.c
+index 7425bf6..1b64506 100644
+--- a/drivers/misc/eeprom/optoe.c
++++ b/drivers/misc/eeprom/optoe.c
+@@ -641,6 +641,7 @@ static ssize_t optoe_read_write(struct optoe_data *optoe,
+ 	ssize_t retval;
+ 	size_t pending_len = 0, chunk_len = 0;
+ 	loff_t chunk_offset = 0, chunk_start_offset = 0;
++	loff_t chunk_end_offset = 0;
+ 
+ 	dev_dbg(&client->dev,
+ 		"%s: off %lld  len:%ld, opcode:%s\n",
+@@ -678,30 +679,30 @@ static ssize_t optoe_read_write(struct optoe_data *optoe,
+ 		/*
+ 		 * Compute the offset and number of bytes to be read/write
+ 		 *
+-		 * 1. start at offset 0 (within the chunk), and read/write
+-		 *    the entire chunk
+-		 * 2. start at offset 0 (within the chunk) and read/write less
+-		 *    than entire chunk
+-		 * 3. start at an offset not equal to 0 and read/write the rest
++		 * 1. start at an offset not equal to 0 (within the chunk)
++		 *    and read/write less than the rest of the chunk
++		 * 2. start at an offset not equal to 0 and read/write the rest
+ 		 *    of the chunk
+-		 * 4. start at an offset not equal to 0 and read/write less than
+-		 *    (end of chunk - offset)
++		 * 3. start at offset 0 (within the chunk) and read/write less
++		 *    than entire chunk
++		 * 4. start at offset 0 (within the chunk), and read/write
++		 *    the entire chunk
+ 		 */
+ 		chunk_start_offset = chunk * OPTOE_PAGE_SIZE;
++		chunk_end_offset = chunk_start_offset + OPTOE_PAGE_SIZE;
+ 
+ 		if (chunk_start_offset < off) {
+ 			chunk_offset = off;
+-			if ((off + pending_len) < (chunk_start_offset +
+-					OPTOE_PAGE_SIZE))
++			if ((off + pending_len) < chunk_end_offset)
+ 				chunk_len = pending_len;
+ 			else
+-				chunk_len = OPTOE_PAGE_SIZE - off;
++				chunk_len = chunk_end_offset - off;
+ 		} else {
+ 			chunk_offset = chunk_start_offset;
+-			if (pending_len > OPTOE_PAGE_SIZE)
+-				chunk_len = OPTOE_PAGE_SIZE;
+-			else
++			if (pending_len < OPTOE_PAGE_SIZE)
+ 				chunk_len = pending_len;
++			else
++				chunk_len = OPTOE_PAGE_SIZE;
+ 		}
+ 
+ 		dev_dbg(&client->dev,

--- a/patch/series
+++ b/patch/series
@@ -32,6 +32,7 @@ driver-hwmon-pmbus-dps1900.patch
 driver-support-tun-config-carrier-enable.patch
 driver-support-optoe.patch
 driver-support-optoe-EOF_fix.patch
+driver-support-optoe-chunk-offset-fix.patch
 bridge-add-per-port-broadcast-flood-flag.patch
 config-dell-s6000.patch
 config-dell-z9100.patch


### PR DESCRIPTION
Correct a panic inducing defect which is triggered on a read (or write)

which begins beyond byte 128, on a byte which is not aligned on a 128 byte
chunk boundary, and which crosses a chunk boundary.

Signed-off-by: Guohan Lu <gulv@microsoft.com>