### PR TITLE
Fix a mlnx hardware-management issue

### DIFF
--- a/patch/0014-mlxsw-qsfp_sysfs-Support-CPLD-version-reading-based-.patch
+++ b/patch/0014-mlxsw-qsfp_sysfs-Support-CPLD-version-reading-based-.patch
@@ -62,14 +62,14 @@ index 3bc6cf8..07cc7ea 100644
  	return sprintf(buf, "%u\n", version);
  }
  
-+static int __init mlxsw_qsfp_dmi_set_cpld_num(const struct dmi_system_id *dmi)
++static int mlxsw_qsfp_dmi_set_cpld_num(const struct dmi_system_id *dmi)
 +{
 +	mlxsw_qsfp_cpld_num = MLXSW_QSFP_MAX_CPLD_NUM;
 +
 +	return 1;
 +};
 +
-+static struct dmi_system_id mlxsw_qsfp_dmi_table[] __initdata = {
++static const struct dmi_system_id mlxsw_qsfp_dmi_table[] = {
 +	{
 +		.callback = mlxsw_qsfp_dmi_set_cpld_num,
 +		.matches = {


### PR DESCRIPTION
Change the attribute of mlxsw_qsfp_dmi_set_cpld_num and
mlxsw_qsfp_dmi_table, let them could be called for multiple times during
kernel boot up.

Signed-off-by: Kevin Wang <kevinw@mellanox.com>