### PR TITLE
Add 2 parameters for driver tg3 can support "short preamble" and "reset".

### DIFF
--- a/patch/driver-net-tg3-add-param-short-preamble-and-reset.patch
+++ b/patch/driver-net-tg3-add-param-short-preamble-and-reset.patch
@@ -5,11 +5,11 @@ Subject: [PATCH] Add 2 more parameter for tg3.c.
 
 Signed-off-by: roy_lee <roy_lee@accton.com>
 ---
- drivers/net/ethernet/broadcom/tg3.c | 20 ++++++++++++++++++++
- 1 file changed, 20 insertions(+)
+ drivers/net/ethernet/broadcom/tg3.c | 19 +++++++++++++++++++
+ 1 file changed, 19 insertions(+)
 
 diff --git a/drivers/net/ethernet/broadcom/tg3.c b/drivers/net/ethernet/broadcom/tg3.c
-index d658255..3d9db7d 100644
+index d658255..d19cf15 100644
 --- a/drivers/net/ethernet/broadcom/tg3.c
 +++ b/drivers/net/ethernet/broadcom/tg3.c
 @@ -234,6 +234,14 @@ static int tg3_debug = -1;	/* -1 == use TG3_DEF_MSG_ENABLE as value */
@@ -27,20 +27,19 @@ index d658255..3d9db7d 100644
  #define TG3_DRV_DATA_FLAG_10_100_ONLY	0x0001
  #define TG3_DRV_DATA_FLAG_5705_10_100	0x0002
  
-@@ -1502,6 +1510,12 @@ static void tg3_mdio_config_5785(struct tg3 *tp)
+@@ -1502,6 +1510,11 @@ static void tg3_mdio_config_5785(struct tg3 *tp)
  static void tg3_mdio_start(struct tg3 *tp)
  {
  	tp->mi_mode &= ~MAC_MI_MODE_AUTO_POLL;
 +
 +	if(short_preamble) {
-+	    netdev_info(tp->dev, "Setting short preamble...");
 +	    tp->mi_mode |= MAC_MI_MODE_SHORT_PREAMBLE;
 +	}
 +
  	tw32_f(MAC_MI_MODE, tp->mi_mode);
  	udelay(80);
  
-@@ -2704,6 +2718,12 @@ static int tg3_phy_reset(struct tg3 *tp)
+@@ -2704,6 +2717,12 @@ static int tg3_phy_reset(struct tg3 *tp)
  		}
  	}
  

--- a/patch/driver-net-tg3-add-param-short-preamble-and-reset.patch
+++ b/patch/driver-net-tg3-add-param-short-preamble-and-reset.patch
@@ -5,11 +5,11 @@ Subject: [PATCH] Add 2 more parameter for tg3.c.
 
 Signed-off-by: roy_lee <roy_lee@accton.com>
 ---
- drivers/net/ethernet/broadcom/tg3.c | 19 +++++++++++++++++++
- 1 file changed, 19 insertions(+)
+ drivers/net/ethernet/broadcom/tg3.c | 18 ++++++++++++++++++
+ 1 file changed, 18 insertions(+)
 
 diff --git a/drivers/net/ethernet/broadcom/tg3.c b/drivers/net/ethernet/broadcom/tg3.c
-index d658255..d19cf15 100644
+index d658255..d31c395 100644
 --- a/drivers/net/ethernet/broadcom/tg3.c
 +++ b/drivers/net/ethernet/broadcom/tg3.c
 @@ -234,6 +234,14 @@ static int tg3_debug = -1;	/* -1 == use TG3_DEF_MSG_ENABLE as value */
@@ -39,12 +39,11 @@ index d658255..d19cf15 100644
  	tw32_f(MAC_MI_MODE, tp->mi_mode);
  	udelay(80);
  
-@@ -2704,6 +2717,12 @@ static int tg3_phy_reset(struct tg3 *tp)
+@@ -2704,6 +2717,11 @@ static int tg3_phy_reset(struct tg3 *tp)
  		}
  	}
  
 +	if (bcm5718s_reset && tp->phy_id == TG3_PHY_ID_BCM5718S) {
-+	    netdev_info(tp->dev, "BCM5718S reset...");
 +	    __tg3_writephy(tp, 0x8, 0x10, 0x1d0); /* set internal phy 0x8 to make linkup */
 +	    __tg3_writephy(tp, 0x1f, 0x4, 0x5e1); /* enable 10/100 cability of external phy */
 +	}

--- a/patch/driver-net-tg3-add-param-short-preamble-and-reset.patch
+++ b/patch/driver-net-tg3-add-param-short-preamble-and-reset.patch
@@ -1,0 +1,58 @@
+Subject: [PATCH] Add 2 more parameter for tg3.c. 
+
+1. short_preamble: Enable mdio traffic to external PHYs(i.g. BCM54616). 
+2. bcm5718s_reset: Enable BCM5718S reset support.
+
+Signed-off-by: roy_lee <roy_lee@accton.com>
+---
+ drivers/net/ethernet/broadcom/tg3.c | 20 ++++++++++++++++++++
+ 1 file changed, 20 insertions(+)
+
+diff --git a/drivers/net/ethernet/broadcom/tg3.c b/drivers/net/ethernet/broadcom/tg3.c
+index d658255..3d9db7d 100644
+--- a/drivers/net/ethernet/broadcom/tg3.c
++++ b/drivers/net/ethernet/broadcom/tg3.c
+@@ -234,6 +234,14 @@ static int tg3_debug = -1;	/* -1 == use TG3_DEF_MSG_ENABLE as value */
+ module_param(tg3_debug, int, 0);
+ MODULE_PARM_DESC(tg3_debug, "Tigon3 bitmapped debugging message enable value");
+ 
++static int short_preamble = 0;
++module_param(short_preamble, int, 0);
++MODULE_PARM_DESC(short_preamble, "Enable short preamble.");
++
++static int bcm5718s_reset = 0;
++module_param(bcm5718s_reset, int, 0);
++MODULE_PARM_DESC(bcm5718s_reset, "Enable BCM5718S reset support.");
++
+ #define TG3_DRV_DATA_FLAG_10_100_ONLY	0x0001
+ #define TG3_DRV_DATA_FLAG_5705_10_100	0x0002
+ 
+@@ -1502,6 +1510,12 @@ static void tg3_mdio_config_5785(struct tg3 *tp)
+ static void tg3_mdio_start(struct tg3 *tp)
+ {
+ 	tp->mi_mode &= ~MAC_MI_MODE_AUTO_POLL;
++
++	if(short_preamble) {
++	    netdev_info(tp->dev, "Setting short preamble...");
++	    tp->mi_mode |= MAC_MI_MODE_SHORT_PREAMBLE;
++	}
++
+ 	tw32_f(MAC_MI_MODE, tp->mi_mode);
+ 	udelay(80);
+ 
+@@ -2704,6 +2718,12 @@ static int tg3_phy_reset(struct tg3 *tp)
+ 		}
+ 	}
+ 
++	if (bcm5718s_reset && tp->phy_id == TG3_PHY_ID_BCM5718S) {
++	    netdev_info(tp->dev, "BCM5718S reset...");
++	    __tg3_writephy(tp, 0x8, 0x10, 0x1d0); /* set internal phy 0x8 to make linkup */
++	    __tg3_writephy(tp, 0x1f, 0x4, 0x5e1); /* enable 10/100 cability of external phy */
++	}
++
+ 	if (tg3_flag(tp, 5717_PLUS) &&
+ 	    (tp->phy_flags & TG3_PHYFLG_MII_SERDES))
+ 		return 0;
+-- 
+2.1.4
+

--- a/patch/series
+++ b/patch/series
@@ -36,6 +36,7 @@ driver-support-optoe.patch
 driver-support-optoe-EOF_fix.patch
 driver-support-optoe-chunk-offset-fix.patch
 bridge-add-per-port-broadcast-flood-flag.patch
+driver-net-tg3-add-param-short-preamble-and-reset.patch
 config-dell-s6000.patch
 config-dell-z9100.patch
 config-ingrasys-s9100.patch


### PR DESCRIPTION
Add "short preamble" parameter for MAC can validate mdio access to some external PHY.
Add "reset" parameter for MAC to reset PHY at driver starting up.

Signed-off-by: roy_lee <roy_lee@accton.com>