### PR TITLE
[security] Upgrade kernel from 4.9.110-3+deb9u2 to 4.9.110-3+deb9u6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,10 @@
 SHELL = /bin/bash
 .SHELLFLAGS += -e
 
-KVERSION_SHORT ?= 4.9.0-7
+KVERSION_SHORT ?= 4.9.0-8
 KVERSION ?= $(KVERSION_SHORT)-amd64
 KERNEL_VERSION ?= 4.9.110
-KERNEL_SUBVERSION ?= 3+deb9u2
+KERNEL_SUBVERSION ?= 3+deb9u6
 kernel_procure_method ?= build
 
 LINUX_HEADER_COMMON = linux-headers-$(KVERSION_SHORT)-common_$(KERNEL_VERSION)-$(KERNEL_SUBVERSION)_all.deb
@@ -18,11 +18,12 @@ DERIVED_TARGETS = $(LINUX_HEADER_AMD64) $(LINUX_IMAGE)
 ifneq ($(kernel_procure_method), build)
 # Downloading kernel
 
-LINUX_HEADER_COMMON_URL = "https://sonicstorage.blob.core.windows.net/packages/kernel-public/linux-headers-4.9.0-7-common_4.9.110-3+deb9u2_all.deb?sv=2015-04-05&sr=b&sig=LlKqKecY6MDSwFMTxpKErh7FX1Lrvse2yVt3niYnhds%3D&se=2128-02-24T04%3A47%3A48Z&sp=r"
+# TBD, need upload the new kernel packages
+LINUX_HEADER_COMMON_URL = "https://sonicstorage.blob.core.windows.net/packages/kernel-public/linux-headers-4.9.0-8-common_4.9.110-3+deb9u2_all.deb?sv=2015-04-05&sr=b&sig=LlKqKecY6MDSwFMTxpKErh7FX1Lrvse2yVt3niYnhds%3D&se=2128-02-24T04%3A47%3A48Z&sp=r"
 
-LINUX_HEADER_AMD64_URL = "https://sonicstorage.blob.core.windows.net/packages/kernel-public/linux-headers-4.9.0-7-amd64_4.9.110-3+deb9u2_amd64.deb?sv=2015-04-05&sr=b&sig=SfQLjiBPPMcRUOmBPvXq2%2F6SsW3ul9%2FlaROplXdGij0%3D&se=2128-02-24T04%3A48%3A38Z&sp=r"
+LINUX_HEADER_AMD64_URL = "https://sonicstorage.blob.core.windows.net/packages/kernel-public/linux-headers-4.9.0-8-amd64_4.9.110-3+deb9u2_amd64.deb?sv=2015-04-05&sr=b&sig=SfQLjiBPPMcRUOmBPvXq2%2F6SsW3ul9%2FlaROplXdGij0%3D&se=2128-02-24T04%3A48%3A38Z&sp=r"
 
-LINUX_IMAGE_URL = "https://sonicstorage.blob.core.windows.net/packages/kernel-public/linux-image-4.9.0-7-amd64_4.9.110-3+deb9u2_amd64.deb?sv=2015-04-05&sr=b&sig=PNKGpLjELZem0IacUMM1jU%2Ft5ujoVvUb9JzxrUhE1Wk%3D&se=2128-02-24T04%3A48%3A57Z&sp=r"
+LINUX_IMAGE_URL = "https://sonicstorage.blob.core.windows.net/packages/kernel-public/linux-image-4.9.0-8-amd64_4.9.110-3+deb9u2_amd64.deb?sv=2015-04-05&sr=b&sig=PNKGpLjELZem0IacUMM1jU%2Ft5ujoVvUb9JzxrUhE1Wk%3D&se=2128-02-24T04%3A48%3A57Z&sp=r"
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	# Obtaining the Debian kernel packages

--- a/patch/preconfig/changelog.patch
+++ b/patch/preconfig/changelog.patch
@@ -14,18 +14,18 @@ index 026b840..88c8a43 100644
 --- a/debian/changelog
 +++ b/debian/changelog
 @@ -1,3 +1,15 @@
-+linux (4.9.110-3+deb9u2) sonic; urgency=high
++linux (4.9.110-3+deb9u6) sonic; urgency=high
 +
 +  * add driver patches for MLNX SN2700
 +
 + -- Guohan Lu <gulv@microsoft.com>  Sun, 19 Dec 2015 01:50:04 +0100
 +
-+linux (4.9.110-3+deb9u2) sonic; urgency=high
++linux (4.9.110-3+deb9u6) sonic; urgency=high
 +
 +  * add support for S6000
 +
 + -- Shuotian Cheng <shuche@microsoft.com>  Sun, 19 Dec 2015 01:50:04 +0100
 +
- linux (4.9.110-3+deb9u2) stretch-security; urgency=high
+ linux (4.9.110-3+deb9u6) stretch-security; urgency=high
  
-   * Revert "net: increase fragment memory usage limits"
+   * [arm64] KVM: Tighten guest core register access from userspace


### PR DESCRIPTION
See changelog for security fixes:
https://tracker.debian.org/media/packages/l/linux/changelog-4.9.110-3deb9u6

Signed-off-by: Zhenggen Xu <zxu@linkedin.com>

Kernel binaries need to be uploaded by MSFT to Azure so when system can build when procure_method is "download"

===Log ===
linux (4.9.110-3+deb9u6) stretch-security; urgency=high

  * [arm64] KVM: Tighten guest core register access from userspace
    (CVE-2018-18021)
  * [arm64] KVM: Sanitize PSTATE.M when being set from userspace
    (CVE-2018-18021)
  * xen-netback: fix input validation in xenvif_set_hash_mapping()
    (CVE-2018-15471)

 -- Salvatore Bonaccorso <carnil@debian.org>  Mon, 08 Oct 2018 08:05:17 +0200

linux (4.9.110-3+deb9u5) stretch-security; urgency=high

  [ Salvatore Bonaccorso ]
  * irda: Fix memory leak caused by repeated binds of irda socket
    (CVE-2018-6554)
  * irda: Only insert new objects into the global database via setsockopt
    (CVE-2018-6555)
  * mm: get rid of vmacache_flush_all() entirely (CVE-2018-17182)
  * floppy: Do not copy a kernel pointer to user memory in FDGETPRM ioctl
    (CVE-2018-7755)
  * Bluetooth: hidp: buffer overflow in hidp_process_report (CVE-2018-9363)
  * ALSA: rawmidi: Change resized buffers atomically (CVE-2018-10902)
  * scsi: target: iscsi: Use hex2bin instead of a re-implementation
    (CVE-2018-14633)
  * [x86] entry/64: Remove %ebx handling from error_entry/exit
    (CVE-2018-14678)
  * infiniband: fix a possible use-after-free bug (CVE-2018-14734)
  * [x86] speculation: Protect against userspace-userspace spectreRSB
    (CVE-2018-15572)
  * [x86] paravirt: Fix spectre-v2 mitigations for paravirt guests
    (CVE-2018-15594)

  [ Ben Hutchings ]
  * mm: Avoid ABI change for CVE-2018-17182 fix
  * HID: debug: check length before copy_to_user() (CVE-2018-9516)
  * Cipso: cipso_v4_optptr enter infinite loop (CVE-2018-10938)
  * f2fs: fix to do sanity check with reserved blkaddr of inline inode
    (CVE-2018-13099)
  * btrfs: relocation: Only remove reloc rb_trees if reloc control has been
    initialized (CVE-2018-14609)
  * hfsplus: fix NULL dereference in hfsplus_lookup() (CVE-2018-14617)
  * USB: yurex: fix out-of-bounds uaccess in read handler (CVE-2018-16276)
  * cdrom: Fix info leak/OOB read in cdrom_ioctl_drive_status (CVE-2018-16658)

 -- Ben Hutchings <ben@decadent.org.uk>  Sun, 30 Sep 2018 17:37:51 +0100

linux (4.9.110-3+deb9u4) stretch-security; urgency=high

  * init: rename and re-order boot_cpu_state_init()
    Adresses boot failures on arm* systems. (Closes: #906769)
  * Sync "cpu/hotplug: Boot HT siblings at least once" from 4.9.120
  * Sync "cpu/hotplug: Non-SMP machines do not make use of booted_once" from
    4.9.120
  * Refresh features/all/rt/0157-softirq-Split-softirq-locks.patch patch.
    Adjust context after applying "init: rename and re-order
    boot_cpu_state_init()".

 -- Salvatore Bonaccorso <carnil@debian.org>  Tue, 21 Aug 2018 16:50:09 +0200

linux (4.9.110-3+deb9u3) stretch-security; urgency=high

  [ Salvatore Bonaccorso ]
  * Add L1 Terminal Fault fixes (CVE-2018-3620, CVE-2018-3646)
    - [x86] speculation/l1tf: Increase 32bit PAE __PHYSICAL_PAGE_SHIFT
    - [x86] mm: move _PAGE_SWP_SOFT_DIRTY from bit 7 to bit 1
    - [x86] speculation/l1tf: Change order of offset/type in swap entry
    - [x86] speculation/l1tf: Protect swap entries against L1TF
    - [x86] speculation/l1tf: Protect PROT_NONE PTEs against speculation
    - [x86] speculation/l1tf: Make sure the first page is always reserved
    - [x86] speculation/l1tf: Add sysfs reporting for l1tf
    - [x86] speculation/l1tf: Disallow non privileged high MMIO PROT_NONE
      mappings
    - [x86] speculation/l1tf: Limit swap file size to MAX_PA/2
    - [x86] bugs: Move the l1tf function and define pr_fmt properly
    - [x86] smp: Provide topology_is_primary_thread()
    - [x86] topology: Provide topology_smt_supported()
    - cpu/hotplug: Make bringup/teardown of smp threads symmetric
    - cpu/hotplug: Split do_cpu_down()
    - cpu/hotplug: Provide knobs to control SMT
    - [x86] cpu: Remove the pointless CPU printout
    - [x86] cpu/AMD: Remove the pointless detect_ht() call
    - [x86] cpu/common: Provide detect_ht_early()
    - [x86] cpu/topology: Provide detect_extended_topology_early()
    - [x86] cpu/intel: Evaluate smp_num_siblings early
    - [x86] CPU/AMD: Do not check CPUID max ext level before parsing SMP
      info
    - [x86] cpu/AMD: Evaluate smp_num_siblings early
    - [x86] apic: Ignore secondary threads if nosmt=force
    - [x86] speculation/l1tf: Extend 64bit swap file size limit
    - [x86] cpufeatures: Add detection of L1D cache flush support.
    - [x86] CPU/AMD: Move TOPOEXT reenablement before reading
      smp_num_siblings
    - [x86] speculation/l1tf: Protect PAE swap entries against L1TF
    - [x86] speculation/l1tf: Fix up pte->pfn conversion for PAE
    - Revert "[x86] apic: Ignore secondary threads if nosmt=force"
    - cpu/hotplug: Boot HT siblings at least once
    - [x86] KVM: Warn user if KVM is loaded SMT and L1TF CPU bug being
      present
    - [x86] KVM/VMX: Add module argument for L1TF mitigation
    - [x86] KVM/VMX: Add L1D flush algorithm
    - [x86] KVM/VMX: Add L1D MSR based flush
    - [x86] KVM/VMX: Add L1D flush logic
    - kvm: nVMX: Update MSR load counts on a VMCS switch
    - [x86] KVM/VMX: Split the VMX MSR LOAD structures to have an
      host/guest numbers
    - [x86] KVM/VMX: Add find_msr() helper function
    - [x86] KVM/VMX: Separate the VMX AUTOLOAD guest/host number
      accounting
    - [x86] KVM/VMX: Extend add_atomic_switch_msr() to allow VMENTER only
      MSRs
    - [x86] KVM/VMX: Use MSR save list for IA32_FLUSH_CMD if required
    - cpu/hotplug: Online siblings when SMT control is turned on
    - [x86] litf: Introduce vmx status variable
    - [x86] kvm: Drop L1TF MSR list approach
    - [x86] l1tf: Handle EPT disabled state proper
    - [x86] kvm: Move l1tf setup function
    - [x86] kvm: Add static key for flush always
    - [x86] kvm: Serialize L1D flush parameter setter
    - [x86] kvm: Allow runtime control of L1D flush
    - cpu/hotplug: Expose SMT control init function
    - cpu/hotplug: Set CPU_SMT_NOT_SUPPORTED early
    - [x86] bugs, kvm: Introduce boot-time control of L1TF mitigations
    - Documentation: Add section about CPU vulnerabilities
    - [x86] KVM/VMX: Initialize the vmx_l1d_flush_pages' content
    - Documentation/l1tf: Fix typos
    - cpu/hotplug: detect SMT disabled by BIOS
    - [x86] KVM/VMX: Don't set l1tf_flush_l1d to true from vmx_l1d_flush()
    - [x86] KVM/VMX: Replace 'vmx_l1d_flush_always' with
      'vmx_l1d_flush_cond'
    - [x86] KVM/VMX: Move the l1tf_flush_l1d test to vmx_l1d_flush()
    - [x86] irq: Demote irq_cpustat_t::__softirq_pending to u16
    - [x86] KVM/VMX: Introduce per-host-cpu analogue of l1tf_flush_l1d
    - [x86] Don't include linux/irq.h from asm/hardirq.h
    - [x86] irq: Let interrupt handlers set kvm_cpu_l1tf_flush_l1d
    - [x86] KVM/VMX: Don't set l1tf_flush_l1d from
      vmx_handle_external_intr()
    - Documentation/l1tf: Remove Yonah processors from not vulnerable
      list
    - [x86] KVM: x86: Add a framework for supporting MSR-based features
    - KVM: SVM: Add MSR-based feature support for serializing LFENCE
    - [x86] KVM: X86: Introduce kvm_get_msr_feature()
    - [x86] KVM: X86: Allow userspace to define the microcode version
    - KVM: VMX: support MSR_IA32_ARCH_CAPABILITIES as a feature MSR
    - [x86] speculation: Simplify sysfs report of VMX L1TF vulnerability
    - [x86] speculation: Use ARCH_CAPABILITIES to skip L1D flush on
      vmentry
    - KVM: VMX: Tell the nested hypervisor to skip L1D flush on vmentry
    - cpu/hotplug: Fix SMT supported evaluation
    - [x86] speculation/l1tf: Invert all not present mappings
    - [x86] speculation/l1tf: Make pmd/pud_mknotpresent() invert
    - [x86] mm/pat: Make set_memory_np() L1TF safe
    - [x86] mm/kmmio: Make the tracer robust against L1TF
    - tools headers: Synchronise x86 cpufeatures.h for L1TF additions
    - [x86] microcode: Do not upload microcode if CPUs are offline
    - [x86] microcode: Allow late microcode loading with SMT disabled
    - [x86] smp: fix non-SMP broken build due to redefinition of
      apic_id_is_primary_thread
    - cpu/hotplug: Non-SMP machines do not make use of booted_once
    - [x86] init: fix build with CONFIG_SWAP=n
    - [x86] speculation/l1tf: Unbreak !__HAVE_ARCH_PFN_MODIFY_ALLOWED
      architectures
    - [x86] cpu/amd: Limit cpu_core_id fixup to families older than F17h
    - [x86] CPU/AMD: Have smp_num_siblings and cpu_llc_id always be
      present
    - [x86] l1tf: Fix build error seen if CONFIG_KVM_INTEL is disabled
    - [x86] i8259: Add missing include file
    - [x86] speculation/l1tf: Exempt zeroed PTEs from inversion

  [ Yves-Alexis Perez ]
  * [rt] refresh 0284-cpu-rt-Rework-cpu-down-for-PREEMPT_RT and
    0286-kernel-cpu-fix-cpu-down-problem-if-kthread-s-cpu-is- context after
    applying L1TF fixes.
  * [rt] update 0281-random-Make-it-work-on-rt to fix builds with recent
    compilers.

  [ Ben Hutchings ]
  * Bump ABI to 8

 -- Salvatore Bonaccorso <carnil@debian.org>  Sun, 19 Aug 2018 15:36:38 +0200