### PR TITLE
Upgrade kernel from 3.16.57-2 to 3.16.59-1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,10 @@
 SHELL = /bin/bash
 .SHELLFLAGS += -e
 
-KVERSION_SHORT ?= 3.16.0-6
+KVERSION_SHORT ?= 3.16.0-7
 KVERSION ?= $(KVERSION_SHORT)-amd64
-KERNEL_VERSION ?= 3.16.57
-KERNEL_SUBVERSION ?= 2
+KERNEL_VERSION ?= 3.16.59
+KERNEL_SUBVERSION ?= 1
 
 MAIN_TARGET = linux-headers-$(KVERSION_SHORT)-common_$(KERNEL_VERSION)-$(KERNEL_SUBVERSION)_amd64.deb
 DERIVED_TARGETS = linux-headers-$(KVERSION)_$(KERNEL_VERSION)-$(KERNEL_SUBVERSION)_amd64.deb \
@@ -17,9 +17,9 @@ DEBIAN_FILE = linux_$(KERNEL_VERSION)-$(KERNEL_SUBVERSION).debian.tar.xz
 URL = http://security.debian.org/debian-security/pool/updates/main/l/linux
 BUILD_DIR=linux-$(KERNEL_VERSION)
 
-DSC_FILE_URL = "https://sonicstorage.blob.core.windows.net/packages/kernel-public/$(DSC_FILE)?sv=2015-04-05&sr=b&sig=MrxcOUmGZALsvb4ROPUqXBbRU8UfVtQi%2FJLWKVqF6WA%3D&se=2155-08-11T16%3A02%3A31Z&sp=r"
-DEBIAN_FILE_URL = "https://sonicstorage.blob.core.windows.net/packages/kernel-public/$(DEBIAN_FILE)?sv=2015-04-05&sr=b&sig=wn66yUesisxcNMJKyUfOy7Ol6qmU0JQWppiADjWOYio%3D&se=2155-08-11T16%3A03%3A01Z&sp=r"
-ORIG_FILE_URL = "https://sonicstorage.blob.core.windows.net/packages/kernel-public/$(ORIG_FILE)?sv=2015-04-05&sr=b&sig=bwePSkU3UAsbZUd0z9QF8Uz%2FQ354QYInijbF3RL0dik%3D&se=2155-08-11T16%3A03%3A23Z&sp=r"
+DSC_FILE_URL = $(URL)/$(DSC_FILE)
+DEBIAN_FILE_URL = $(URL)/$(DEBIAN_FILE)
+ORIG_FILE_URL = $(URL)/$(ORIG_FILE)
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	# Obtaining the Debian kernel source

--- a/patch/changelog.patch
+++ b/patch/changelog.patch
@@ -1,6 +1,6 @@
 From a96e033ed01d4a68a0825c187bebe45a527fb868 Mon Sep 17 00:00:00 2001
 From: Zhenggen Xu <zxu@linkedin.com> 
-Date: Tue Oct 2 23:03:23 2018 -0700 
+Date: Mon Jan 21 23:13:15 2019 -0800 
 Subject: [PATCH] Update changelog
 
 Signed-off-by: Zhenggen Xu <zxu@linkedin.com>
@@ -13,18 +13,18 @@ index baeab31..9cdcdfc 100644
 --- a/debian/changelog
 +++ b/debian/changelog
 @@ -1,3 +1,15 @@
-+linux (3.16.57-2) sonic; urgency=high
++linux (3.16.59-1) sonic; urgency=high
 +
 +  * add driver patches for MLNX SN2700
 +
 + -- Guohan Lu <gulv@microsoft.com>  Sun, 19 Dec 2015 01:50:04 +0100
 +
-+linux (3.16.57-2) sonic; urgency=high
++linux (3.16.59-1) sonic; urgency=high
 +
 +  * add support for S6000
 +
 + -- Shuotian Cheng <shuche@microsoft.com>  Sun, 19 Dec 2015 01:50:04 +0100
 +
- linux (3.16.57-2) jessie-security; urgency=high
+ linux (3.16.59-1) jessie-security; urgency=high
  
-   * mmc/host: Ignore ABI changes (fixes FTBFS on armhf)
+   * New upstream stable update:


### PR DESCRIPTION
Upgrade kernel from 3.16.57-2 to 3.16.59-1
Signed-off-by: Zhenggen Xu <zxu@linkedin.com>

====
Fix below issues:
linux (3.16.59-1) jessie-security; urgency=high

  * New upstream stable update:
    https://www.kernel.org/pub/linux/kernel/v3.x/ChangeLog-3.16.58
    - net: Set sk_prot_creator when cloning sockets to the right proto
    - Bluetooth: hidp: buffer overflow in hidp_process_report (CVE-2018-9363)
    - scsi: libsas: defer ata device eh commands to libata (CVE-2018-10021)
    - xfs: set format back to extents if xfs_bmap_extents_to_btree
      (CVE-2018-10323)
    - ext4: only look at the bg_flags field if it is valid (CVE-2018-10876)
    - ext4: fix check to prevent initializing reserved inodes
    - ext4: verify the depth of extent tree in ext4_find_extent()
      (CVE-2018-10877)
    - ext4: always check block group bounds in ext4_init_block_bitmap()
      (CVE-2018-10878)
    - ext4: don't allow r/w mounts if metadata blocks overlap the superblock
    - ext4: make sure bitmaps and the inode table don't overlap with bg
      descriptors (CVE-2018-10878)
    - ext4: fix false negatives *and* false positives in
      ext4_check_descriptors()
    - ext4: add corruption check in ext4_xattr_set_entry() (CVE-2018-10879)
    - ext4: always verify the magic number in xattr blocks (CVE-2018-10879)
    - ext4: never move the system.data xattr out of the inode body
      (CVE-2018-10880)
    - ext4: clear i_data in ext4_inode_info when removing inline data
      (CVE-2018-10881)
    - ext4: add more inode number paranoia checks (CVE-2018-10882)
    - jbd2: don't mark block as modified if the handle is out of credits
      (CVE-2018-10883)
    - ext4: avoid running out of journal credits when appending to an inline
      file (CVE-2018-10883)
    - Fix up non-directory creation in SGID directories (CVE-2018-13405)
    - [amd64] entry: Remove %ebx handling from error_entry/exit
      (CVE-2018-14678)
    - infiniband: fix a possible use-after-free bug (CVE-2018-14734)
    - USB: yurex: fix out-of-bounds uaccess in read handler (CVE-2018-16276)
    - ALSA: rawmidi: Change resized buffers atomically (CVE-2018-10902)
    - [x86] speculation: Clean up various Spectre related details
    - [x86] speculation: Protect against userspace-userspace spectreRSB
      (CVE-2018-15572)
    - [x86] paravirt: Fix spectre-v2 mitigations for paravirt guests
      (CVE-2018-15594)
    - cdrom: Fix info leak/OOB read in cdrom_ioctl_drive_status
      (CVE-2018-16658)
    - uas: replace WARN_ON_ONCE() with lockdep_assert_held()
    - video: uvesafb: Fix integer overflow in allocation (CVE-2018-13406)
    - btrfs: relocation: Only remove reloc rb_trees if reloc control has been
      initialized (CVE-2018-14609)
    - hfsplus: fix NULL dereference in hfsplus_lookup() (CVE-2018-14617)
    - xfs: catch inode allocation state mismatch corruption
    - xfs: validate cached inodes are free when allocated (CVE-2018-13093)
    - xfs: don't call xfs_da_shrink_inode with NULL bp (CVE-2018-13094)
    - seccomp: create internal mode-setting function
    - seccomp: extract check/assign mode helpers
    - seccomp: split mode setting routines
    - seccomp: add "seccomp" syscall
    - [x86] process: Optimize TIF checks in __switch_to_xtra()
    - [x86] process: Correct and optimize TIF_BLOCKSTEP switch
    - [x86] cpu/AMD: Fix erratum 1076 (CPB bit)
    - [x86] cpu/intel: Add Knights Mill to Intel family
    - [x86] KVM: introduce num_emulated_msrs
    - mm: get rid of vmacache_flush_all() entirely (CVE-2018-17182)
    https://www.kernel.org/pub/linux/kernel/v3.x/ChangeLog-3.16.59
    - [x86] Add support for disabling Speculative Store Bypass (CVE-2018-3639)
      + x86/nospec: Simplify alternative_msr_write()
      + x86/bugs: Concentrate bug detection into a separate function
      + x86/bugs: Concentrate bug reporting into a separate function
      + x86/bugs: Read SPEC_CTRL MSR during boot and re-use reserved bits
      + x86/bugs, KVM: Support the combination of guest and host IBRS
      + x86/bugs: Expose /sys/../spec_store_bypass
      + x86/cpufeatures: Add X86_FEATURE_RDS
      + x86/bugs: Provide boot parameters for the spec_store_bypass_disable
        mitigation
      + x86/bugs/intel: Set proper CPU features and setup RDS
      + x86/bugs: Whitelist allowed SPEC_CTRL MSR values
      + x86/bugs/AMD: Add support to disable RDS on Fam[15,16,17]h if requested
      + x86/KVM/VMX: Expose SPEC_CTRL Bit(2) to the guest
      + x86/speculation: Create spec-ctrl.h to avoid include hell
      + prctl: Add speculation control prctls
      + x86/process: Allow runtime control of Speculative Store Bypass
      + x86/speculation: Add prctl for Speculative Store Bypass mitigation
      + nospec: Allow getting/setting on non-current task
      + proc: Provide details on speculation flaw mitigations
      + seccomp: Enable speculation flaw mitigations
      + prctl: Add force disable speculation
      + seccomp: Use PR_SPEC_FORCE_DISABLE
      + seccomp: Add filter flag to opt-out of SSB mitigation
      + seccomp: Move speculation migitation control to arch code
      + x86/speculation: Make "seccomp" the default mode for Speculative Store
        Bypass
      + x86/bugs: Rename _RDS to _SSBD
      + proc: Use underscores for SSBD in 'status'
      + Documentation/spec_ctrl: Do some minor cleanups
      + x86/bugs: Fix __ssb_select_mitigation() return type
      + x86/bugs: Make cpu_show_common() static
      + x86/bugs: Fix the parameters alignment and missing void
      + x86/cpu: Make alternative_msr_write work for 32-bit code
      + KVM: SVM: Move spec control call after restore of GS
      + x86/speculation: Use synthetic bits for IBRS/IBPB/STIBP
      + x86/cpufeatures: Disentangle MSR_SPEC_CTRL enumeration from IBRS
      + x86/cpufeatures: Disentangle SSBD enumeration
      + x86/cpufeatures: Add FEATURE_ZEN
      + x86/speculation: Handle HT correctly on AMD
      + x86/bugs, KVM: Extend speculation control for VIRT_SPEC_CTRL
      + x86/speculation: Add virtualized speculative store bypass disable
        support
      + x86/speculation: Rework speculative_store_bypass_update()
      + x86/bugs: Unify x86_spec_ctrl_{set_guest,restore_host}
      + x86/bugs: Expose x86_spec_ctrl_base directly
      + x86/bugs: Remove x86_spec_ctrl_set()
      + x86/bugs: Rework spec_ctrl base and mask logic
      + x86/speculation, KVM: Implement support for VIRT_SPEC_CTRL/LS_CFG
      + KVM: SVM: Implement VIRT_SPEC_CTRL support for SSBD
      + x86/bugs: Rename SSBD_NO to SSB_NO
      + KVM/VMX: Expose SSBD properly to guests
      + KVM: x86: SVM: Call x86_spec_ctrl_set_guest/host() with interrupts
        disabled
      + x86/xen: Add call of speculative_store_bypass_ht_init() to PV paths
    - [x86] cpufeatures: Show KAISER in cpuinfo
    - mm: Remove non-linear file mappings:
      + mm: replace remap_file_pages() syscall with emulation
      + mm: fix regression in remap_file_pages() emulation
      + mm: drop support of non-linear mapping from unmap/zap codepath
      + mm: drop support of non-linear mapping from fault codepath
      + mm: drop vm_ops->remap_pages and generic_file_remap_pages() stub
      + proc: drop handling non-linear mappings
      + rmap: drop support of non-linear mappings
      + mm: replace vma->sharead.linear with vma->shared
      + mm: remove rest usage of VM_NONLINEAR and pte_file()
      + asm-generic: drop unused pte_file* helpers
      + arm: drop L_PTE_FILE and pte_file()-related helpers
      + x86: drop _PAGE_FILE and pte_file()-related helpers
    - [x86] mm: Move swap offset/type up in PTE to work around erratum
    - [x86] mm: move _PAGE_SWP_SOFT_DIRTY from bit 7 to bit 1
    - [x86] mm: Add PUD functions
    - mm: Add vm_insert_pfn_prot()
    - mm: fix cache mode tracking in vm_insert_mixed()
    - [x86] io: add interface to reserve io memtype for a resource range
    - drm/drivers: add support for using the arch wc mapping API.
    - mm/pagewalk: remove pgd_entry() and pud_entry()
    - pagewalk: improve vma handling
    - [x86] Add mitigation for L1 Terminal Fault (kernel) (CVE-2018-3620):
      + x86/speculation/l1tf: Increase 32bit PAE __PHYSICAL_PAGE_SHIFT
      + x86/speculation/l1tf: Change order of offset/type in swap entry
      + x86/speculation/l1tf: Protect swap entries against L1TF
      + x86/speculation/l1tf: Protect PROT_NONE PTEs against speculation
      + x86/speculation/l1tf: Make sure the first page is always reserved
      + x86/speculation/l1tf: Add sysfs reporting for l1tf
      + x86/speculation/l1tf: Disallow non privileged high MMIO PROT_NONE
        mappings
      + x86/speculation/l1tf: Limit swap file size to MAX_PA/2
      + x86/init: fix build with CONFIG_SWAP=n
      + x86/bugs: Move the l1tf function and define pr_fmt properly
      + x86/speculation/l1tf: Extend 64bit swap file size limit
      + x86/speculation/l1tf: Protect PAE swap entries against L1TF
      + x86/speculation/l1tf: Fix overflow in l1tf_pfn_limit() on 32bit
      + x86/speculation/l1tf: Fix off-by-one error when warning that system has
        too much RAM
      + x86/speculation/l1tf: Fix up pte->pfn conversion for PAE
      + x86/speculation/l1tf: Unbreak !__HAVE_ARCH_PFN_MODIFY_ALLOWED
        architectures
      + x86/speculation/l1tf: Invert all not present mappings
      + x86/speculation/l1tf: Exempt zeroed PTEs from inversion
      + x86/speculation/l1tf: Protect NUMA-balance entries against L1TF
      + x86/speculation/l1tf: Make pmd/pud_mknotpresent() invert
      + x86/mm/pat: Make set_memory_np() L1TF safe
      + x86/mm/kmmio: Make the tracer robust against L1TF
      + x86/speculation/l1tf: Suggest what to do on systems with too much RAM
    - mm/vmstat: Make NR_TLB_REMOTE_FLUSH_RECEIVED available even on UP
    - irda: Fix memory leak caused by repeated binds of irda socket
      (CVE-2018-6554)
    - irda: Only insert new objects into the global database via setsockopt
      (CVE-2018-6555)
    - floppy: Do not copy a kernel pointer to user memory in FDGETPRM ioctl
      (CVE-2018-7755)
    - HID: debug: check length before copy_to_user() (CVE-2018-9516)
    - scsi: target: iscsi: Use hex2bin instead of a re-implementation
      (CVE-2018-14633)
    - exec: Limit arg stack to at most 75% of _STK_LIM (CVE-2018-14634)

  [ Salvatore Bonaccorso ]
  * nfsd: increase DRC cache limit (Closes: #898137)

  [ Ben Hutchings ]
  * Revert "net: increase fragment memory usage limits" (CVE-2018-5391)
  * debian/control: Point Vcs URLs to Salsa
  * README.Debian: Change more URLs to use https: scheme
  * README.Debian: Update URLs that were pointing to Alioth
  * Bump ABI to 7

 -- Ben Hutchings <ben@decadent.org.uk>  Wed, 03 Oct 2018 04:25:08 +0100

See also:
https://tracker.debian.org/media/packages/l/linux/changelog-3.16.59-1

# test
with changes in sonic-buildimage:
diff --git a/rules/linux-kernel.mk b/rules/linux-kernel.mk
index 1fb0d1e7..0eb11963 100644
--- a/rules/linux-kernel.mk
+++ b/rules/linux-kernel.mk
@@ -1,9 +1,9 @@
// # linux kernel package
 
-KVERSION_SHORT = 3.16.0-6
+KVERSION_SHORT = 3.16.0-7
 KVERSION ?= $(KVERSION_SHORT)-amd64
-KERNEL_VERSION = 3.16.57
-KERNEL_SUBVERSION = 2
+KERNEL_VERSION = 3.16.59
+KERNEL_SUBVERSION = 1
 
 export KVERSION_SHORT KVERSION KERNEL_VERSION KERNEL_SUBVERSION

I could successfully build below:
linux-headers-3.16.0-7-amd64_3.16.59-1_amd64.deb
linux-image-3.16.0-7-amd64_3.16.59-1_amd64.deb
linux-headers-3.16.0-7-common_3.16.59-1_amd64.deb

Need MSFT to build the opennsl packages to fully tests.  I will be part of the sonic-buildimage PR later.