### PR TITLE
[kernel] upgrade to version linux_4.9.168-1+deb9u5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ KERNEL_ABI_MINOR_VERSION = 2
 KVERSION_SHORT ?= 4.9.0-9-$(KERNEL_ABI_MINOR_VERSION)
 KVERSION ?= $(KVERSION_SHORT)-amd64
 KERNEL_VERSION ?= 4.9.168
-KERNEL_SUBVERSION ?= 1+deb9u3
+KERNEL_SUBVERSION ?= 1+deb9u5
 kernel_procure_method ?= build
 
 LINUX_HEADER_COMMON = linux-headers-$(KVERSION_SHORT)-common_$(KERNEL_VERSION)-$(KERNEL_SUBVERSION)_all.deb
@@ -47,8 +47,8 @@ ORIG_FILE = linux_$(KERNEL_VERSION).orig.tar.xz
 DEBIAN_FILE = linux_$(KERNEL_VERSION)-$(KERNEL_SUBVERSION).debian.tar.xz
 BUILD_DIR=linux-$(KERNEL_VERSION)
 
-DSC_FILE_URL = "https://sonicstorage.blob.core.windows.net/packages/kernel-source/linux_4.9.168-1+deb9u3.dsc?sv=2015-04-05&sr=b&sig=MoOJMteUh46D9tG0axEPbw%2BeoFOrOtrP36BLmY7P6rs%3D&se=2033-04-09T00%3A59%3A43Z&sp=r"
-DEBIAN_FILE_URL = "https://sonicstorage.blob.core.windows.net/packages/kernel-source/linux_4.9.168-1+deb9u3.debian.tar.xz?sv=2015-04-05&sr=b&sig=MNrNMhg8dbJOn1FxTZslQwOnblAfNhRghAsozwDK5QI%3D&se=2033-04-09T01%3A00%3A14Z&sp=r"
+DSC_FILE_URL = "https://sonicstorage.blob.core.windows.net/packages/kernel-source/linux_4.9.168-1+deb9u5.dsc?sv=2015-04-05&sr=b&sig=ZcTpvRltWLWwnJn3vQ%2BgTP1dVF6QSinOCJ1FSuyiogU%3D&se=2033-04-28T06%3A14%3A30Z&sp=r"
+DEBIAN_FILE_URL = "https://sonicstorage.blob.core.windows.net/packages/kernel-source/linux_4.9.168-1+deb9u5.debian.tar.xz?sv=2015-04-05&sr=b&sig=koCXHDvmY39smVGcI3cPJrBDZMmdpKiLkyJPfMdNPwU%3D&se=2033-04-28T06%3A14%3A51Z&sp=r"
 ORIG_FILE_URL = "https://sonicstorage.blob.core.windows.net/packages/kernel-source/linux_4.9.168.orig.tar.xz?sv=2015-04-05&sr=b&sig=ArvSGD3N46WGh%2BTYF8J1JgdT9x0BrFu4JhSuyyr3nNw%3D&se=2033-04-09T01%3A00%3A47Z&sp=r"
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :

--- a/patch/preconfig/changelog.patch
+++ b/patch/preconfig/changelog.patch
@@ -14,18 +14,18 @@ index 026b840..88c8a43 100644
 --- a/debian/changelog
 +++ b/debian/changelog
 @@ -1,3 +1,15 @@
-+linux (4.9.168-1+deb9u3) sonic; urgency=high
++linux (4.9.168-1+deb9u5) sonic; urgency=high
 +
 +  * add driver patches for MLNX SN2700
 +
 + -- Guohan Lu <gulv@microsoft.com>  Sun, 19 Dec 2015 01:50:04 +0100
 +
-+linux (4.9.168-1+deb9u3) sonic; urgency=high
++linux (4.9.168-1+deb9u5) sonic; urgency=high
 +
 +  * add support for S6000
 +
 + -- Shuotian Cheng <shuche@microsoft.com>  Sun, 19 Dec 2015 01:50:04 +0100
 +
- linux (4.9.168-1+deb9u3) stretch-security; urgency=high
- 
-   [ Salvatore Bonaccorso ]
+ linux (4.9.168-1+deb9u5) stretch-security; urgency=high
+
+   * [amd64] Add mitigation for Spectre v1 swapgs (CVE-2019-1125):


### PR DESCRIPTION
upgrade kernel to version linux_4.9.168-1+deb9u5

- pick up security patches

Signed-off-by: Ying Xie <ying.xie@microsoft.com>