### PR TITLE
[kernel] add patch for mlx-platform: Fix parent device in i2c-mux-reg device registration

### DIFF
--- a/patch/0026-4.14.-15-56-platform-x86-mlx-platform-Fix-parent-device-in-i2c-mux-reg-device-registration.patch
+++ b/patch/0026-4.14.-15-56-platform-x86-mlx-platform-Fix-parent-device-in-i2c-mux-reg-device-registration.patch
@@ -1,0 +1,212 @@
+From patchwork Mon Jul  8 15:13:07 2019
+Content-Type: text/plain; charset="utf-8"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+X-Patchwork-Submitter: Greg KH <gregkh@linuxfoundation.org>
+X-Patchwork-Id: 1098431
+Return-Path: <SRS0=4ODY=VF=vger.kernel.org=linux-kernel-owner@kernel.org>
+Received: from mail.kernel.org (mail.kernel.org [198.145.29.99])
+	by smtp.lore.kernel.org (Postfix) with ESMTP id 65E64C606C1
+	for <linux-kernel@archiver.kernel.org>; Mon,  8 Jul 2019 15:26:07 +0000 (UTC)
+Received: from vger.kernel.org (vger.kernel.org [209.132.180.67])
+	by mail.kernel.org (Postfix) with ESMTP id 333F221537
+	for <linux-kernel@archiver.kernel.org>; Mon,  8 Jul 2019 15:26:07 +0000 (UTC)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/simple; d=kernel.org;
+	s=default; t=1562599567;
+	bh=mv6hFB3s7ta5L3rV55CfDeYsbhbVrljDVRgxZsB2vG4=;
+	h=From:To:Cc:Subject:Date:In-Reply-To:References:List-ID:From;
+	b=Kizq4VfKZWOlsepo7unMvOC5XRaDbPQlpiFrdx5grhgpthpvdAIvpUzOF78v/NynQ
+	 9WUSK2BSP2EejmRTcCs9iZrpGQ17GEBaxizRnbSdDrqDhPQj+P3mZm5JyCC3pkNOVA
+	 +5Tr0HIhhQkBxAH+6DhnqqY1QOWBR0PiEven5BYo=
+Received: (majordomo@vger.kernel.org) by vger.kernel.org via listexpand
+        id S2388750AbfGHP0G (ORCPT
+        <rfc822;linux-kernel@archiver.kernel.org>);
+        Mon, 8 Jul 2019 11:26:06 -0400
+Received: from mail.kernel.org ([198.145.29.99]:53688 "EHLO mail.kernel.org"
+        rhost-flags-OK-OK-OK-OK) by vger.kernel.org with ESMTP
+        id S2388733AbfGHP0D (ORCPT <rfc822;linux-kernel@vger.kernel.org>);
+        Mon, 8 Jul 2019 11:26:03 -0400
+Received: from localhost (83-86-89-107.cable.dynamic.v4.ziggo.nl
+ [83.86.89.107])
+        (using TLSv1.2 with cipher ECDHE-RSA-AES256-GCM-SHA384 (256/256 bits))
+        (No client certificate requested)
+        by mail.kernel.org (Postfix) with ESMTPSA id 23C3D21537;
+        Mon,  8 Jul 2019 15:26:01 +0000 (UTC)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/simple; d=kernel.org;
+        s=default; t=1562599562;
+        bh=mv6hFB3s7ta5L3rV55CfDeYsbhbVrljDVRgxZsB2vG4=;
+        h=From:To:Cc:Subject:Date:In-Reply-To:References:From;
+        b=OjrhHouciia2s2ukkolYpmLZ9/pe9Q+xlXwMrniSmVXf6iyeJ4QuSxyzY02vv+t8n
+         jcf7/YboDJUXUX2zHRhzIClvETmwHVi6IGzmHiZbLx6Hm6TBy2FpC2fygNRlWiIUFK
+         Q02j0GCqnfT1UzjO6rqYvFuaWyY8SWrfznXgYuNs=
+From: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+To: linux-kernel@vger.kernel.org
+Cc: Greg Kroah-Hartman <gregkh@linuxfoundation.org>,
+        stable@vger.kernel.org, Vadim Pasternak <vadimp@mellanox.com>,
+        Andy Shevchenko <andriy.shevchenko@linux.intel.com>,
+        Sasha Levin <sashal@kernel.org>
+Subject: [PATCH 4.14 15/56] platform/x86: mlx-platform: Fix parent device in
+ i2c-mux-reg device registration
+Date: Mon,  8 Jul 2019 17:13:07 +0200
+Message-Id: <20190708150519.851598649@linuxfoundation.org>
+X-Mailer: git-send-email 2.22.0
+In-Reply-To: <20190708150514.376317156@linuxfoundation.org>
+References: <20190708150514.376317156@linuxfoundation.org>
+User-Agent: quilt/0.66
+MIME-Version: 1.0
+Sender: linux-kernel-owner@vger.kernel.org
+Precedence: bulk
+List-ID: <linux-kernel.vger.kernel.org>
+X-Mailing-List: linux-kernel@vger.kernel.org
+
+[ Upstream commit 160da20b254dd4bfc5828f12c208fa831ad4be6c ]
+
+Fix the issue found while running kernel with the option
+CONFIG_DEBUG_TEST_DRIVER_REMOVE.
+Driver 'mlx-platform' registers 'i2c_mlxcpld' device and then registers
+few underlying 'i2c-mux-reg' devices:
+	priv->pdev_i2c = platform_device_register_simple("i2c_mlxcpld", nr,
+							 NULL, 0);
+	...
+	for (i = 0; i < ARRAY_SIZE(mlxplat_mux_data); i++) {
+		priv->pdev_mux[i] = platform_device_register_resndata(
+						&mlxplat_dev->dev,
+						"i2c-mux-reg", i, NULL,
+						0, &mlxplat_mux_data[i],
+						sizeof(mlxplat_mux_data[i]));
+
+But actual parent of "i2c-mux-reg" device is priv->pdev_i2c->dev and
+not mlxplat_dev->dev.
+Patch fixes parent device parameter in a call to
+platform_device_register_resndata() for "i2c-mux-reg".
+
+It solves the race during initialization flow while 'i2c_mlxcpld.1' is
+removing after probe, while 'i2c-mux-reg.0' is still in probing flow:
+'i2c_mlxcpld.1'	flow:	probe -> remove -> probe.
+'i2c-mux-reg.0'	flow:		  probe -> ...
+
+[   12:621096] Registering platform device 'i2c_mlxcpld.1'. Parent at platform
+[   12:621117] device: 'i2c_mlxcpld.1': device_add
+[   12:621155] bus: 'platform': add device i2c_mlxcpld.1
+[   12:621384] Registering platform device 'i2c-mux-reg.0'. Parent at mlxplat
+[   12:621395] device: 'i2c-mux-reg.0': device_add
+[   12:621425] bus: 'platform': add device i2c-mux-reg.0
+[   12:621806] Registering platform device 'i2c-mux-reg.1'. Parent at mlxplat
+[   12:621828] device: 'i2c-mux-reg.1': device_add
+[   12:621892] bus: 'platform': add device i2c-mux-reg.1
+[   12:621906] bus: 'platform': add driver i2c_mlxcpld
+[   12:621996] bus: 'platform': driver_probe_device: matched device i2c_mlxcpld.1 with driver i2c_mlxcpld
+[   12:622003] bus: 'platform': really_probe: probing driver i2c_mlxcpld with device i2c_mlxcpld.1
+[   12:622100] i2c_mlxcpld i2c_mlxcpld.1: no default pinctrl state
+[   12:622293] device: 'i2c-1': device_add
+[   12:627280] bus: 'i2c': add device i2c-1
+[   12:627692] device: 'i2c-1': device_add
+[   12.629639] bus: 'platform': add driver i2c-mux-reg
+[   12.629718] bus: 'platform': driver_probe_device: matched device i2c-mux-reg.0 with driver i2c-mux-reg
+[   12.629723] bus: 'platform': really_probe: probing driver i2c-mux-reg with device i2c-mux-reg.0
+[   12.629818] i2c-mux-reg i2c-mux-reg.0: no default pinctrl state
+[   12.629981] platform i2c-mux-reg.0: Driver i2c-mux-reg requests probe deferral
+[   12.629986] platform i2c-mux-reg.0: Added to deferred list
+[   12.629992] bus: 'platform': driver_probe_device: matched device i2c-mux-reg.1 with driver i2c-mux-reg
+[   12.629997] bus: 'platform': really_probe: probing driver i2c-mux-reg with device i2c-mux-reg.1
+[   12.630091] i2c-mux-reg i2c-mux-reg.1: no default pinctrl state
+[   12.630247] platform i2c-mux-reg.1: Driver i2c-mux-reg requests probe deferral
+[   12.630252] platform i2c-mux-reg.1: Added to deferred list
+[   12.640892] devices_kset: Moving i2c-mux-reg.0 to end of list
+[   12.640900] platform i2c-mux-reg.0: Retrying from deferred list
+[   12.640911] bus: 'platform': driver_probe_device: matched device i2c-mux-reg.0 with driver i2c-mux-reg
+[   12.640919] bus: 'platform': really_probe: probing driver i2c-mux-reg with device i2c-mux-reg.0
+[   12.640999] i2c-mux-reg i2c-mux-reg.0: no default pinctrl state
+[   12.641177] platform i2c-mux-reg.0: Driver i2c-mux-reg requests probe deferral
+[   12.641187] platform i2c-mux-reg.0: Added to deferred list
+[   12.641198] devices_kset: Moving i2c-mux-reg.1 to end of list
+[   12.641219] platform i2c-mux-reg.1: Retrying from deferred list
+[   12.641237] bus: 'platform': driver_probe_device: matched device i2c-mux-reg.1 with driver i2c-mux-reg
+[   12.641247] bus: 'platform': really_probe: probing driver i2c-mux-reg with device i2c-mux-reg.1
+[   12.641331] i2c-mux-reg i2c-mux-reg.1: no default pinctrl state
+[   12.641465] platform i2c-mux-reg.1: Driver i2c-mux-reg requests probe deferral
+[   12.641469] platform i2c-mux-reg.1: Added to deferred list
+[   12.646427] device: 'i2c-1': device_add
+[   12.646647] bus: 'i2c': add device i2c-1
+[   12.647104] device: 'i2c-1': device_add
+[   12.669231] devices_kset: Moving i2c-mux-reg.0 to end of list
+[   12.669240] platform i2c-mux-reg.0: Retrying from deferred list
+[   12.669258] bus: 'platform': driver_probe_device: matched device i2c-mux-reg.0 with driver i2c-mux-reg
+[   12.669263] bus: 'platform': really_probe: probing driver i2c-mux-reg with device i2c-mux-reg.0
+[   12.669343] i2c-mux-reg i2c-mux-reg.0: no default pinctrl state
+[   12.669585] device: 'i2c-2': device_add
+[   12.669795] bus: 'i2c': add device i2c-2
+[   12.670201] device: 'i2c-2': device_add
+[   12.671427] i2c i2c-1: Added multiplexed i2c bus 2
+[   12.671514] device: 'i2c-3': device_add
+[   12.671724] bus: 'i2c': add device i2c-3
+[   12.672136] device: 'i2c-3': device_add
+[   12.673378] i2c i2c-1: Added multiplexed i2c bus 3
+[   12.673472] device: 'i2c-4': device_add
+[   12.673676] bus: 'i2c': add device i2c-4
+[   12.674060] device: 'i2c-4': device_add
+[   12.675861] i2c i2c-1: Added multiplexed i2c bus 4
+[   12.675941] device: 'i2c-5': device_add
+[   12.676150] bus: 'i2c': add device i2c-5
+[   12.676550] device: 'i2c-5': device_add
+[   12.678103] i2c i2c-1: Added multiplexed i2c bus 5
+[   12.678193] device: 'i2c-6': device_add
+[   12.678395] bus: 'i2c': add device i2c-6
+[   12.678774] device: 'i2c-6': device_add
+[   12.679969] i2c i2c-1: Added multiplexed i2c bus 6
+[   12.680065] device: 'i2c-7': device_add
+[   12.680275] bus: 'i2c': add device i2c-7
+[   12.680913] device: 'i2c-7': device_add
+[   12.682506] i2c i2c-1: Added multiplexed i2c bus 7
+[   12.682600] device: 'i2c-8': device_add
+[   12.682808] bus: 'i2c': add device i2c-8
+[   12.683189] device: 'i2c-8': device_add
+[   12.683907] device: 'i2c-1': device_unregister
+[   12.683945] device: 'i2c-1': device_unregister
+[   12.684387] device: 'i2c-1': device_create_release
+[   12.684536] bus: 'i2c': remove device i2c-1
+[   12.686019] i2c i2c-8: Failed to create compatibility class link
+[   12.686086] ------------[ cut here ]------------
+[   12.686087] can't create symlink to mux device
+[   12.686224] Workqueue: events deferred_probe_work_func
+[   12.686135] WARNING: CPU: 7 PID: 436 at drivers/i2c/i2c-mux.c:416 i2c_mux_add_adapter+0x729/0x7d0 [i2c_mux]
+[   12.686232] RIP: 0010:i2c_mux_add_adapter+0x729/0x7d0 [i2c_mux]
+[   0x190/0x190 [i2c_mux]
+[   12.686300]  ? i2c_mux_alloc+0xac/0x110 [i2c_mux]
+[   12.686306]  ? i2c_mux_reg_set+0x200/0x200 [i2c_mux_reg]
+[   12.686313]  i2c_mux_reg_probe+0x22c/0x731 [i2c_mux_reg]
+[   12.686322]  ? i2c_mux_reg_deselect+0x60/0x60 [i2c_mux_reg]
+[   12.686346]  platform_drv_probe+0xa8/0x110
+[   12.686351]  really_probe+0x185/0x720
+[   12.686358]  driver_probe_device+0xdf/0x1f0
+...
+[   12.686522] i2c i2c-1: Added multiplexed i2c bus 8
+[   12.686621] device: 'i2c-9': device_add
+[   12.686626] kobject_add_internal failed for i2c-9 (error: -2 parent: i2c-1)
+[   12.694729] i2c-core: adapter 'i2c-1-mux (chan_id 8)': can't register device (-2)
+[   12.705726] i2c i2c-1: failed to add mux-adapter 8 as bus 9 (error=-2)
+[   12.714494] device: 'i2c-8': device_unregister
+[   12.714537] device: 'i2c-8': device_unregister
+
+Fixes: 6613d18e9038 ("platform/x86: mlx-platform: Move module from arch/x86")
+Signed-off-by: Vadim Pasternak <vadimp@mellanox.com>
+Signed-off-by: Andy Shevchenko <andriy.shevchenko@linux.intel.com>
+Signed-off-by: Sasha Levin <sashal@kernel.org>
+---
+ drivers/platform/x86/mlx-platform.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
+index 4f3de2a8c4df..9aced80f31a2 100644
+--- a/drivers/platform/x86/mlx-platform.c
++++ b/drivers/platform/x86/mlx-platform.c
+@@ -318,7 +318,7 @@ static int __init mlxplat_init(void)
+ 
+ 	for (i = 0; i < ARRAY_SIZE(mlxplat_mux_data); i++) {
+ 		priv->pdev_mux[i] = platform_device_register_resndata(
+-						&mlxplat_dev->dev,
++						&priv->pdev_i2c->dev,
+ 						"i2c-mux-reg", i, NULL,
+ 						0, &mlxplat_mux_data[i],
+ 						sizeof(mlxplat_mux_data[i]));
+

--- a/patch/series
+++ b/patch/series
@@ -56,6 +56,7 @@ linux-4.13-thermal-intel_pch_thermal-Fix-enable-check-on.patch
 0023-platform-x86-mlx-platform-Add-support-for-register-a.patch
 0024-config-mellanox-fan-configuration.patch
 0025-mlxsw-qsfp_sysfs-Remove-qsfp-valid-time.patch
+0026-4.14.-15-56-platform-x86-mlx-platform-Fix-parent-device-in-i2c-mux-reg-device-registration.patch
 #
 # This series applies on GIT commit 1451b36b2b0d62178e42f648d8a18131af18f7d8
 # Tkernel-sched-core-fix-cgroup-fork-race.patch


### PR DESCRIPTION
Patch fixes parent device parameter in a call to
platform_device_register_resndata() for "i2c-mux-reg".

It solves the race during initialization flow while 'i2c_mlxcpld.1' is
removing after probe, while 'i2c-mux-reg.0' is still in probing flow.

Signed-off-by: Mykola Faryma <mykolaf@mellanox.com>