### PR TITLE
Add linux patch to fix 'ipv6: Handle missing host route in __ipv6_ifa_notify'

### DIFF
--- a/patch/net-backport-ipv6-missing-route.patch
+++ b/patch/net-backport-ipv6-missing-route.patch
@@ -1,0 +1,34 @@
+The below patch has been backported to fix "ipv6: Handle missing host route in __ipv6_ifa_notify"
+
+https://github.com/torvalds/linux/commit/2d819d250a1393a3e725715425ab70a0e0772a71#diff-0907850728440370acc820310df76f30
+
+diff --git a/net/ipv6/addrconf.c b/net/ipv6/addrconf.c
+index cb5aaf4..79c1012 100644
+--- a/net/ipv6/addrconf.c
++++ b/net/ipv6/addrconf.c
+@@ -5402,13 +5402,20 @@ static void __ipv6_ifa_notify(int event, struct inet6_ifaddr *ifp)
+ 	switch (event) {
+ 	case RTM_NEWADDR:
+ 		/*
+-		 * If the address was optimistic
+-		 * we inserted the route at the start of
+-		 * our DAD process, so we don't need
+-		 * to do it again
++		 * If the address was optimistic we inserted the route at the
++		 * start of our DAD process, so we don't need to do it again.
++		 * If the device was taken down in the middle of the DAD
++		 * cycle there is a race where we could get here without a
++		 * host route, so nothing to insert. That will be fixed when
++		 * the device is brought up.
+ 		 */
+-		if (!rcu_access_pointer(ifp->rt->rt6i_node))
++		if (ifp->rt && !rcu_access_pointer(ifp->rt->rt6i_node)) {
+ 			ip6_ins_rt(ifp->rt);
++		} else if (!ifp->rt && (ifp->idev->dev->flags & IFF_UP)) {
++			pr_warn("BUG: Address %pI6c on device %s is missing its host route.\n",
++				&ifp->addr, ifp->idev->dev->name);
++		}
++
+ 		if (ifp->idev->cnf.forwarding)
+ 			addrconf_join_anycast(ifp);
+ 		if (!ipv6_addr_any(&ifp->peer_addr))

--- a/patch/series
+++ b/patch/series
@@ -90,6 +90,7 @@ kernel-enable-psample-and-act_sample-drivers.patch
 0000-net-Fix-netdev-adjacency-tracking.patch
 0000-net-ipv6-ll-anycast-mcast-routes-on-dev.patch
 0001-net-ipv6-Allow-shorthand-delete-of-all-nexthops-in-m.patch
+net-backport-ipv6-missing-route.patch
 #
 # This series applies on GIT commit 1451b36b2b0d62178e42f648d8a18131af18f7d8
 # Tkernel-sched-core-fix-cgroup-fork-race.patch


### PR DESCRIPTION
The below patch has been backported from latest linux to fix the kernel crash reported in  [Azure/sonic-builimage#3831](https://github.com/Azure/sonic-buildimage/issues/3831)

 'ipv6: Handle missing host route in __ipv6_ifa_notify'

https://github.com/torvalds/linux/commit/2d819d250a1393a3e725715425ab70a0e0772a71#diff-0907850728440370acc820310df76f30
