### PR TITLE
[Mellanox] Add the driver patches for hw-mgmt V7.0000.2308

### DIFF
--- a/patch/0048-mlxsw-core-Skip-thermal-zone-operations-initializati.patch
+++ b/patch/0048-mlxsw-core-Skip-thermal-zone-operations-initializati.patch
@@ -1,0 +1,101 @@
+From 2a2cd8876916ffaf530053a5e1f05940258eab86 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@mellanox.com>
+Date: Tue, 5 Nov 2019 15:25:22 +0200
+Subject: [PATCH v1] mlxsw: core: Skip thermal zone operations initialization
+
+Skip thermal zones setting for modules to reduce probing time.
+It is to be read anyway during thermal zone operations.
+Skip thermal zone setting and reading during initialization.
+
+Decrease i2c controller polling time from 2000usec to 200usec
+for the performance improvement.
+
+Signed-off-by: Vadim Pasternak <vadimp@mellanox.com>
+---
+ drivers/i2c/busses/i2c-mlxcpld.c                   |  2 +-
+ drivers/net/ethernet/mellanox/mlxsw/core_thermal.c | 21 +++++++++++++++++++++
+ 2 files changed, 22 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/i2c/busses/i2c-mlxcpld.c b/drivers/i2c/busses/i2c-mlxcpld.c
+index 2fd717d8dd30..41b57027e348 100644
+--- a/drivers/i2c/busses/i2c-mlxcpld.c
++++ b/drivers/i2c/busses/i2c-mlxcpld.c
+@@ -51,7 +51,7 @@
+ #define MLXCPLD_I2C_MAX_ADDR_LEN	4
+ #define MLXCPLD_I2C_RETR_NUM		2
+ #define MLXCPLD_I2C_XFER_TO		500000 /* usec */
+-#define MLXCPLD_I2C_POLL_TIME		2000   /* usec */
++#define MLXCPLD_I2C_POLL_TIME		200   /* usec */
+ 
+ /* LPC I2C registers */
+ #define MLXCPLD_LPCI2C_CPBLTY_REG	0x0
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c b/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
+index dfaad30ae960..08458e30e171 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
++++ b/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
+@@ -116,6 +116,7 @@ struct mlxsw_thermal {
+ 	u8 tz_gearbox_num;
+ 	unsigned int tz_highest_score;
+ 	struct thermal_zone_device *tz_highest_dev;
++	bool initializing; /* Driver is in initialization stage */
+ };
+ 
+ static inline u8 mlxsw_state_to_duty(int state)
+@@ -287,6 +288,12 @@ static int mlxsw_thermal_get_temp(struct thermal_zone_device *tzdev,
+ 	int temp;
+ 	int err;
+ 
++	/* Do not read temperature in initialization stage. */
++	if (thermal->initializing) {
++		*p_temp = 0;
++		return 0;
++	}
++
+ 	mlxsw_reg_mtmp_pack(mtmp_pl, 0, false, false);
+ 
+ 	err = mlxsw_reg_query(thermal->core, MLXSW_REG(mtmp), mtmp_pl);
+@@ -458,6 +465,12 @@ static int mlxsw_thermal_module_temp_get(struct thermal_zone_device *tzdev,
+ 	int temp;
+ 	int err;
+ 
++	/* Do not read temperature in initialization stage. */
++	if (thermal->initializing) {
++		*p_temp = 0;
++		return 0;
++	}
++
+ 	/* Read module temperature. */
+ 	mlxsw_reg_mtmp_pack(mtmp_pl, MLXSW_REG_MTMP_MODULE_INDEX_MIN +
+ 			    tz->module, false, false);
+@@ -565,6 +578,12 @@ static int mlxsw_thermal_gearbox_temp_get(struct thermal_zone_device *tzdev,
+ 	int temp;
+ 	int err;
+ 
++	/* Do not read temperature in initialization stage. */
++	if (thermal->initializing) {
++		*p_temp = 0;
++		return 0;
++	}
++
+ 	index = MLXSW_REG_MTMP_GBOX_INDEX_MIN + tz->module;
+ 	mlxsw_reg_mtmp_pack(mtmp_pl, index, false, false);
+ 
+@@ -919,6 +938,7 @@ int mlxsw_thermal_init(struct mlxsw_core *core,
+ 	thermal->core = core;
+ 	thermal->bus_info = bus_info;
+ 	memcpy(thermal->trips, default_thermal_trips, sizeof(thermal->trips));
++	thermal->initializing = true;
+ 
+ 	err = mlxsw_reg_query(thermal->core, MLXSW_REG(mfcr), mfcr_pl);
+ 	if (err) {
+@@ -994,6 +1014,7 @@ int mlxsw_thermal_init(struct mlxsw_core *core,
+ 		goto err_unreg_modules_tzdev;
+ 
+ 	thermal->mode = THERMAL_DEVICE_DISABLED;
++	thermal->initializing = false;
+ 	*p_thermal = thermal;
+ 	return 0;
+ 
+-- 
+2.11.0
+

--- a/patch/0049-thermal-Fix-use-after-free-when-unregistering-therma.patch
+++ b/patch/0049-thermal-Fix-use-after-free-when-unregistering-therma.patch
@@ -1,0 +1,138 @@
+From 09246e73df900b96b534d6b7ccd26a681facb4d5 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@mellanox.com>
+Date: Tue, 26 Nov 2019 09:09:45 +0200
+Subject: [PATCH backport bugfix from v5.3] thermal: Fix use-after-free when
+ unregistering thermal zone device
+
+Upstream commit 1851799e1d2978f68eea5d9dff322e121dcf59c1
+Author: Ido Schimmel <idosch@mellanox.com>
+Date:   Wed Jul 10 13:14:52 2019 +0300
+
+thermal: Fix use-after-free when unregistering thermal zone device
+
+thermal_zone_device_unregister() cancels the delayed work that polls the
+thermal zone, but it does not wait for it to finish. This is racy with
+respect to the freeing of the thermal zone device, which can result in a
+use-after-free [1].
+
+Fix this by waiting for the delayed work to finish before freeing the
+thermal zone device. Note that thermal_zone_device_set_polling() is
+never invoked from an atomic context, so it is safe to call
+cancel_delayed_work_sync() that can block.
+
+[1]
+[  +0.002221] ==================================================================
+[  +0.000064] BUG: KASAN: use-after-free in __mutex_lock+0x1076/0x11c0
+[  +0.000016] Read of size 8 at addr ffff8881e48e0450 by task kworker/1:0/17
+
+[  +0.000023] CPU: 1 PID: 17 Comm: kworker/1:0 Not tainted 5.2.0-rc6-custom-02495-g8e73ca3be4af #1701
+[  +0.000010] Hardware name: Mellanox Technologies Ltd. MSN2100-CB2FO/SA001017, BIOS 5.6.5 06/07/2016
+[  +0.000016] Workqueue: events_freezable_power_ thermal_zone_device_check
+[  +0.000012] Call Trace:
+[  +0.000021]  dump_stack+0xa9/0x10e
+[  +0.000020]  print_address_description.cold.2+0x9/0x25e
+[  +0.000018]  __kasan_report.cold.3+0x78/0x9d
+[  +0.000016]  kasan_report+0xe/0x20
+[  +0.000016]  __mutex_lock+0x1076/0x11c0
+[  +0.000014]  step_wise_throttle+0x72/0x150
+[  +0.000018]  handle_thermal_trip+0x167/0x760
+[  +0.000019]  thermal_zone_device_update+0x19e/0x5f0
+[  +0.000019]  process_one_work+0x969/0x16f0
+[  +0.000017]  worker_thread+0x91/0xc40
+[  +0.000014]  kthread+0x33d/0x400
+[  +0.000015]  ret_from_fork+0x3a/0x50
+
+[  +0.000020] Allocated by task 1:
+[  +0.000015]  save_stack+0x19/0x80
+[  +0.000015]  __kasan_kmalloc.constprop.4+0xc1/0xd0
+[  +0.000014]  kmem_cache_alloc_trace+0x152/0x320
+[  +0.000015]  thermal_zone_device_register+0x1b4/0x13a0
+[  +0.000015]  mlxsw_thermal_init+0xc92/0x23d0
+[  +0.000014]  __mlxsw_core_bus_device_register+0x659/0x11b0
+[  +0.000013]  mlxsw_core_bus_device_register+0x3d/0x90
+[  +0.000013]  mlxsw_pci_probe+0x355/0x4b0
+[  +0.000014]  local_pci_probe+0xc3/0x150
+[  +0.000013]  pci_device_probe+0x280/0x410
+[  +0.000013]  really_probe+0x26a/0xbb0
+[  +0.000013]  driver_probe_device+0x208/0x2e0
+[  +0.000013]  device_driver_attach+0xfe/0x140
+[  +0.000013]  __driver_attach+0x110/0x310
+[  +0.000013]  bus_for_each_dev+0x14b/0x1d0
+[  +0.000013]  driver_register+0x1c0/0x400
+[  +0.000015]  mlxsw_sp_module_init+0x5d/0xd3
+[  +0.000014]  do_one_initcall+0x239/0x4dd
+[  +0.000013]  kernel_init_freeable+0x42b/0x4e8
+[  +0.000012]  kernel_init+0x11/0x18b
+[  +0.000013]  ret_from_fork+0x3a/0x50
+
+[  +0.000015] Freed by task 581:
+[  +0.000013]  save_stack+0x19/0x80
+[  +0.000014]  __kasan_slab_free+0x125/0x170
+[  +0.000013]  kfree+0xf3/0x310
+[  +0.000013]  thermal_release+0xc7/0xf0
+[  +0.000014]  device_release+0x77/0x200
+[  +0.000014]  kobject_put+0x1a8/0x4c0
+[  +0.000014]  device_unregister+0x38/0xc0
+[  +0.000014]  thermal_zone_device_unregister+0x54e/0x6a0
+[  +0.000014]  mlxsw_thermal_fini+0x184/0x35a
+[  +0.000014]  mlxsw_core_bus_device_unregister+0x10a/0x640
+[  +0.000013]  mlxsw_devlink_core_bus_device_reload+0x92/0x210
+[  +0.000015]  devlink_nl_cmd_reload+0x113/0x1f0
+[  +0.000014]  genl_family_rcv_msg+0x700/0xee0
+[  +0.000013]  genl_rcv_msg+0xca/0x170
+[  +0.000013]  netlink_rcv_skb+0x137/0x3a0
+[  +0.000012]  genl_rcv+0x29/0x40
+[  +0.000013]  netlink_unicast+0x49b/0x660
+[  +0.000013]  netlink_sendmsg+0x755/0xc90
+[  +0.000013]  __sys_sendto+0x3de/0x430
+[  +0.000013]  __x64_sys_sendto+0xe2/0x1b0
+[  +0.000013]  do_syscall_64+0xa4/0x4d0
+[  +0.000013]  entry_SYSCALL_64_after_hwframe+0x49/0xbe
+
+[  +0.000017] The buggy address belongs to the object at ffff8881e48e0008
+   which belongs to the cache kmalloc-2k of size 2048
+[  +0.000012] The buggy address is located 1096 bytes inside of
+   2048-byte region [ffff8881e48e0008, ffff8881e48e0808)
+[  +0.000007] The buggy address belongs to the page:
+[  +0.000012] page:ffffea0007923800 refcount:1 mapcount:0 mapping:ffff88823680d0c0 index:0x0 compound_mapcount: 0
+[  +0.000020] flags: 0x200000000010200(slab|head)
+[  +0.000019] raw: 0200000000010200 ffffea0007682008 ffffea00076ab808 ffff88823680d0c0
+[  +0.000016] raw: 0000000000000000 00000000000d000d 00000001ffffffff 0000000000000000
+[  +0.000007] page dumped because: kasan: bad access detected
+
+[  +0.000012] Memory state around the buggy address:
+[  +0.000012]  ffff8881e48e0300: fb fb fb fb fb fb fb fb fb fb fb fb fb fb fb fb
+[  +0.000012]  ffff8881e48e0380: fb fb fb fb fb fb fb fb fb fb fb fb fb fb fb fb
+[  +0.000012] >ffff8881e48e0400: fb fb fb fb fb fb fb fb fb fb fb fb fb fb fb fb
+[  +0.000008]  ^
+[  +0.000012]  ffff8881e48e0480: fb fb fb fb fb fb fb fb fb fb fb fb fb fb fb fb
+[  +0.000012]  ffff8881e48e0500: fb fb fb fb fb fb fb fb fb fb fb fb fb fb fb fb
+[  +0.000007] ==================================================================
+
+Fixes: b1569e99c795 ("ACPI: move thermal trip handling to generic thermal layer")
+Reported-by: Jiri Pirko <jiri@mellanox.com>
+Signed-off-by: Ido Schimmel <idosch@mellanox.com>
+Acked-by: Jiri Pirko <jiri@mellanox.com>
+Signed-off-by: Zhang Rui <rui.zhang@intel.com>
+
+Signed-off-by: Vadim Pasternak <vadimp@mellanox.com>
+---
+ drivers/thermal/thermal_core.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/thermal/thermal_core.c b/drivers/thermal/thermal_core.c
+index 226b0b4aced6..7be7017f0d9e 100644
+--- a/drivers/thermal/thermal_core.c
++++ b/drivers/thermal/thermal_core.c
+@@ -402,7 +402,7 @@ static void thermal_zone_device_set_polling(struct thermal_zone_device *tz,
+ 		mod_delayed_work(system_freezable_wq, &tz->poll_queue,
+ 				 msecs_to_jiffies(delay));
+ 	else
+-		cancel_delayed_work(&tz->poll_queue);
++		cancel_delayed_work_sync(&tz->poll_queue);
+ }
+ 
+ static void monitor_thermal_zone(struct thermal_zone_device *tz)
+-- 
+2.11.0
+

--- a/patch/0050-mlxsw-core-Drop-creation-of-thermal-to-hwmon-sysfs-i.patch
+++ b/patch/0050-mlxsw-core-Drop-creation-of-thermal-to-hwmon-sysfs-i.patch
@@ -1,0 +1,73 @@
+From 539b36ac336510610b22b134284af5ecb2dc5009 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@mellanox.com>
+Date: Thu, 28 Nov 2019 08:34:22 +0200
+Subject: [PATCH mlxsw: thermal] mlxsw: core: Drop creation of thermal to hwmon
+ sysfs interface
+
+Drop creation of "hwmon" interfaces from "thermal". These interfaces
+are redundant, since they are created by "core_hwmon" component.
+Creation of those interface from "thermal" just causes each temperature
+input entry to by created twice in "hwmon"
+Add thermal zone platform parameters definition with the field
+"no_hwmon" set to true. Use it in thermal_zone_device_register().
+It will indicate that the "thermal" to "hwmon" sysfs interface is not
+required.
+
+Signed-off-by: Vadim Pasternak <vadimp@mellanox.com>
+---
+ drivers/net/ethernet/mellanox/mlxsw/core_thermal.c | 18 +++++++++++-------
+ 1 file changed, 11 insertions(+), 7 deletions(-)
+
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c b/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
+index c4a426d01c5e..f234416305fd 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
++++ b/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
+@@ -411,6 +411,10 @@ static int mlxsw_thermal_trend_get(struct thermal_zone_device *tzdev,
+ 	return 0;
+ }
+ 
++struct thermal_zone_params mlxsw_thermal_params = {
++	.no_hwmon = true,
++};
++
+ static struct thermal_zone_device_ops mlxsw_thermal_ops = {
+ 	.bind = mlxsw_thermal_bind,
+ 	.unbind = mlxsw_thermal_unbind,
+@@ -774,11 +778,11 @@ mlxsw_thermal_module_tz_init(struct mlxsw_thermal_module *module_tz)
+ 	snprintf(tz_name, sizeof(tz_name), "mlxsw-module%d",
+ 		 module_tz->module + 1);
+ 	module_tz->tzdev = thermal_zone_device_register(tz_name,
+-							MLXSW_THERMAL_NUM_TRIPS,
+-							MLXSW_THERMAL_TRIP_MASK,
+-							module_tz,
+-							&mlxsw_thermal_module_ops,
+-							NULL, 0, 0);
++						MLXSW_THERMAL_NUM_TRIPS,
++						MLXSW_THERMAL_TRIP_MASK,
++						module_tz,
++						&mlxsw_thermal_module_ops,
++						&mlxsw_thermal_params, 0, 0);
+ 	if (IS_ERR(module_tz->tzdev)) {
+ 		err = PTR_ERR(module_tz->tzdev);
+ 		return err;
+@@ -898,7 +902,7 @@ mlxsw_thermal_gearbox_tz_init(struct mlxsw_thermal_module *gearbox_tz)
+ 						MLXSW_THERMAL_TRIP_MASK,
+ 						gearbox_tz,
+ 						&mlxsw_thermal_gearbox_ops,
+-						NULL, 0, 0);
++						&mlxsw_thermal_params, 0, 0);
+ 	if (IS_ERR(gearbox_tz->tzdev))
+ 		return PTR_ERR(gearbox_tz->tzdev);
+ 
+@@ -1052,7 +1056,7 @@ int mlxsw_thermal_init(struct mlxsw_core *core,
+ 						      MLXSW_THERMAL_TRIP_MASK,
+ 						      thermal,
+ 						      &mlxsw_thermal_ops,
+-						      NULL, 0,
++						      &mlxsw_thermal_params, 0,
+ 						      thermal->polling_delay);
+ 	if (IS_ERR(thermal->tzdev)) {
+ 		err = PTR_ERR(thermal->tzdev);
+-- 
+2.11.0
+

--- a/patch/0051-mlxsw-core-Skip-thermal-zones-threshold-setting-duri.patch
+++ b/patch/0051-mlxsw-core-Skip-thermal-zones-threshold-setting-duri.patch
@@ -1,0 +1,34 @@
+From 031b57148672ff229d42fe4401e552c05e14f87a Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@mellanox.com>
+Date: Sun, 1 Dec 2019 17:29:02 +0200
+Subject: [PATCH mlxsw: thermal] mlxsw: core: Skip thermal zones threshold
+ setting during initialization
+
+Skip modules' thermal zones threshold setting during initialization in
+order to reduce driver's probing time.
+This setting will be performed at the first operation with the thermal
+zones.
+
+Signed-off-by: Vadim Pasternak vadimp@mellanox.com
+---
+ drivers/net/ethernet/mellanox/mlxsw/core_thermal.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c b/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
+index 7fbb7a24eb63..f234416305fd 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
++++ b/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
+@@ -813,8 +813,8 @@ mlxsw_thermal_module_init(struct device *dev, struct mlxsw_core *core,
+ 	       sizeof(thermal->trips));
+ 	/* Initialize all trip point. */
+ 	mlxsw_thermal_module_trips_reset(module_tz);
+-	/* Update trip point according to the module data. */
+-	return mlxsw_thermal_module_trips_update(dev, core, module_tz);
++
++	return 0;
+ }
+ 
+ static void mlxsw_thermal_module_fini(struct mlxsw_thermal_module *module_tz)
+-- 
+2.20.1
+

--- a/patch/0052-platform-x86-mlx-platform-Add-more-detention-for-sys.patch
+++ b/patch/0052-platform-x86-mlx-platform-Add-more-detention-for-sys.patch
@@ -1,0 +1,35 @@
+From 5df12806208285231c63a8757208648483aaf395 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@mellanox.com>
+Date: Tue, 3 Dec 2019 16:02:08 +0200
+Subject: [PATCH platform] platform/x86: mlx-platform: Add more detention for
+ system attributes
+
+Add new attribute for "next-generation" type systems:
+"reset_sw_pwr_off" for indication of reset caused by
+software power off command.
+
+Signed-off-by: Vadim Pasternak <vadimp@mellanox.com>
+---
+ drivers/platform/x86/mlx-platform.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
+index c3e75b26fe0b..765baf99de60 100644
+--- a/drivers/platform/x86/mlx-platform.c
++++ b/drivers/platform/x86/mlx-platform.c
+@@ -1335,6 +1335,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
+ 		.mask = GENMASK(7, 0) & ~BIT(1),
+ 		.mode = 0444,
+ 	},
++	{
++		.label = "reset_sw_pwr_off",
++		.reg = MLXPLAT_CPLD_LPC_REG_RST_CAUSE2_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(2),
++		.mode = 0444,
++	},
+ 	{
+ 		.label = "reset_comex_thermal",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_RST_CAUSE2_OFFSET,
+-- 
+2.20.1
+

--- a/patch/series
+++ b/patch/series
@@ -83,6 +83,11 @@ linux-4.13-thermal-intel_pch_thermal-Fix-enable-check-on.patch
 0045-mlxsw-minimal-Add-validation-for-FW-version.patch
 0046-mlxsw-core-Extend-QSFP-EEPROM-supported-size-for-eth.patch
 0047-mfd-lpc-ich-extend-with-additional-chipsets-support.patch
+0048-mlxsw-core-Skip-thermal-zone-operations-initializati.patch
+0049-thermal-Fix-use-after-free-when-unregistering-therma.patch
+0050-mlxsw-core-Drop-creation-of-thermal-to-hwmon-sysfs-i.patch
+0051-mlxsw-core-Skip-thermal-zones-threshold-setting-duri.patch
+0052-platform-x86-mlx-platform-Add-more-detention-for-sys.patch
 linux-4.16-firmware-dmi-handle-missing-DMI-data-gracefully.patch
 mellanox-backport-introduce-psample-a-new-genetlink-channel.patch
 mellanox-backport-introduce-tc-sample-action.patch


### PR DESCRIPTION
patch/0048-mlxsw-core-Skip-thermal-zone-operations-initializati.patch
patch/0049-thermal-Fix-use-after-free-when-unregistering-therma.patch
patch/0050-mlxsw-core-Drop-creation-of-thermal-to-hwmon-sysfs-i.patch
patch/0051-mlxsw-core-Skip-thermal-zones-threshold-setting-duri.patch
patch/0052-platform-x86-mlx-platform-Add-more-detention-for-sys.patch