### PR TITLE
Add ixgbe driver patch to support BCM54616S_E_PHY phy

### DIFF
--- a/patch/driver-ixgbe-external-phy.patch
+++ b/patch/driver-ixgbe-external-phy.patch
@@ -1,0 +1,57 @@
+From: Jostar Yang <jostar_yang@accton.com>
+Signed-off-by: Jostar Yang <jostar_yang@accton.com>
+
+
+diff --git a/drivers/net/ethernet/intel/ixgbe/ixgbe_phy.c b/drivers/net/ethernet/intel/ixgbe/ixgbe_phy.c
+index b17464e..29d267d 100644
+--- a/drivers/net/ethernet/intel/ixgbe/ixgbe_phy.c
++++ b/drivers/net/ethernet/intel/ixgbe/ixgbe_phy.c
+@@ -429,6 +429,9 @@ static enum ixgbe_phy_type ixgbe_get_phy_type_from_id(u32 phy_id)
+ 	case X557_PHY_ID:
+ 		phy_type = ixgbe_phy_x550em_ext_t;
+ 		break;
++	case BCM54616S_E_PHY_ID:
++		phy_type = ixgbe_phy_ext_1g_t;
++		break;
+ 	default:
+ 		phy_type = ixgbe_phy_unknown;
+ 		break;
+diff --git a/drivers/net/ethernet/intel/ixgbe/ixgbe_type.h b/drivers/net/ethernet/intel/ixgbe/ixgbe_type.h
+index 31d82e3..94d6306 100644
+--- a/drivers/net/ethernet/intel/ixgbe/ixgbe_type.h
++++ b/drivers/net/ethernet/intel/ixgbe/ixgbe_type.h
+@@ -1401,6 +1401,7 @@ struct ixgbe_thermal_sensor_data {
+ 
+ /* PHY Types */
+ #define IXGBE_M88E1145_E_PHY_ID  0x01410CD0
++#define BCM54616S_E_PHY_ID       0x03625D10
+ 
+ /* Special PHY Init Routine */
+ #define IXGBE_PHY_INIT_OFFSET_NL 0x002B
+@@ -3060,6 +3061,7 @@ enum ixgbe_phy_type {
+ 	ixgbe_phy_x550em_kr,
+ 	ixgbe_phy_x550em_kx4,
+ 	ixgbe_phy_x550em_ext_t,
++	ixgbe_phy_ext_1g_t,
+ 	ixgbe_phy_cu_unknown,
+ 	ixgbe_phy_qt,
+ 	ixgbe_phy_xaui,
+diff --git a/drivers/net/ethernet/intel/ixgbe/ixgbe_x550.c b/drivers/net/ethernet/intel/ixgbe/ixgbe_x550.c
+index 8466f38..033b2eb 100644
+--- a/drivers/net/ethernet/intel/ixgbe/ixgbe_x550.c
++++ b/drivers/net/ethernet/intel/ixgbe/ixgbe_x550.c
+@@ -1716,8 +1716,12 @@ static s32 ixgbe_get_link_capabilities_X550em(struct ixgbe_hw *hw,
+ 		else
+ 			*speed = IXGBE_LINK_SPEED_10GB_FULL;
+ 	} else {
+-		*speed = IXGBE_LINK_SPEED_10GB_FULL |
+-			 IXGBE_LINK_SPEED_1GB_FULL;
++		if (hw->phy.type == ixgbe_phy_ext_1g_t) {
++			*speed = IXGBE_LINK_SPEED_1GB_FULL;
++		} else {
++			*speed = IXGBE_LINK_SPEED_10GB_FULL |
++			IXGBE_LINK_SPEED_1GB_FULL;
++		}
+ 		*autoneg = true;
+ 	}
+ 	return 0;

--- a/patch/series
+++ b/patch/series
@@ -103,6 +103,7 @@ net-psample-fix-skb-over-panic.patch
 0001-net-ipv6-Allow-shorthand-delete-of-all-nexthops-in-m.patch
 net-backport-ipv6-missing-route.patch
 Support-for-fullcone-nat.patch
+driver-ixgbe-external-phy.patch
 #
 # This series applies on GIT commit 1451b36b2b0d62178e42f648d8a18131af18f7d8
 # Tkernel-sched-core-fix-cgroup-fork-race.patch


### PR DESCRIPTION
This PR is patch for IXGBE.
0011-support-Broadcom-54616-Phy-for-Intel-igb-driver.patch is for IGB.
They are different code.
Do format with checkpatch.pl.

sonic-buildimage/src/sonic-linux-kernel/linux-4.9.168$ ./scripts/checkpatch.pl driver-ixgbe-external-phy.patch
total: 0 errors, 0 warnings, 0 checks, 37 lines checked

