### PR TITLE
[net-fix-skb-csum-update-in-inet_proto_csum_replace16.patch]: net: Fi…

### DIFF
--- a/patch/net-fix-skb-csum-update-in-inet_proto_csum_replace16.patch
+++ b/patch/net-fix-skb-csum-update-in-inet_proto_csum_replace16.patch
@@ -1,0 +1,56 @@
+skb->csum is updated incorrectly, when manipulation for NF_NAT_MANIP_SRC\DST
+is done on IPV6 packet.
+
+Fix:
+There is no need to update skb->csum in inet_proto_csum_replace16(), because
+update in two fields a.) IPv6 src/dst address and b.) L4 header checksum
+cancels each other for skb->csum calculation.
+Whereas inet_proto_csum_replace4 function needs to update skb->csum,
+because update in 3 fields a.) IPv4 src/dst address, b.) IPv4 Header checksum
+and c.) L4 header checksum results in same diff as L4 Header checksum for
+skb->csum calculation.
+
+Signed-off-by: Praveen Chaudhary <pchaudhary@linkedin.com>
+Signed-off-by: Zhenggen Xu <zxu@linkedin.com>
+Signed-off-by: Andy Stracner <astracner@linkedin.com>
+
+Reviewed-by: Florian Westphal <fw@strlen.de>
+---
+diff --git a/net/core/utils.c b/net/core/utils.c
+index cf5622b..3317f90 100644
+--- a/net/core/utils.c
++++ b/net/core/utils.c
+@@ -316,6 +316,23 @@ void inet_proto_csum_replace4(__sum16 *sum, struct sk_buff *skb,
+ }
+ EXPORT_SYMBOL(inet_proto_csum_replace4);
+ 
++/**
++ * inet_proto_csum_replace16 - update layer 4 header checksum field
++ * @sum: Layer 4 header checksum field
++ * @skb: sk_buff for the packet
++ * @from: old IPv6 address
++ * @to: new IPv6 address
++ * @pseudohdr: True if layer 4 header checksum includes pseudoheader
++ *
++ * Update layer 4 header as per the update in IPv6 src/dst address.
++ *
++ * There is no need to update skb->csum in this function, because update in two
++ * fields a.) IPv6 src/dst address and b.) L4 header checksum cancels each other
++ * for skb->csum calculation. Whereas inet_proto_csum_replace4 function needs to
++ * update skb->csum, because update in 3 fields a.) IPv4 src/dst address,
++ * b.) IPv4 Header checksum and c.) L4 header checksum results in same diff as
++ * L4 Header checksum for skb->csum calculation.
++ */
+ void inet_proto_csum_replace16(__sum16 *sum, struct sk_buff *skb,
+ 			       const __be32 *from, const __be32 *to,
+ 			       bool pseudohdr)
+@@ -327,9 +344,6 @@ void inet_proto_csum_replace16(__sum16 *sum, struct sk_buff *skb,
+ 	if (skb->ip_summed != CHECKSUM_PARTIAL) {
+ 		*sum = csum_fold(csum_partial(diff, sizeof(diff),
+ 				 ~csum_unfold(*sum)));
+-		if (skb->ip_summed == CHECKSUM_COMPLETE && pseudohdr)
+-			skb->csum = ~csum_partial(diff, sizeof(diff),
+-						  ~skb->csum);
+ 	} else if (pseudohdr)
+ 		*sum = ~csum_fold(csum_partial(diff, sizeof(diff),
+ 				  csum_unfold(*sum)));

--- a/patch/series
+++ b/patch/series
@@ -110,6 +110,7 @@ net-backport-ipv6-missing-route.patch
 Support-for-fullcone-nat.patch
 driver-ixgbe-external-phy.patch
 fix_ismt_alignment_issue.patch
+net-fix-skb-csum-update-in-inet_proto_csum_replace16.patch
 #
 # This series applies on GIT commit 1451b36b2b0d62178e42f648d8a18131af18f7d8
 # Tkernel-sched-core-fix-cgroup-fork-race.patch


### PR DESCRIPTION
…x skb->csum update in inet_proto_csum_replace16().

Bringing below patch in sonic-linux-kernel.
https://github.com/torvalds/linux/commit/189c9b1e94539b11c80636bc13e9cf47529e7bba#diff-c857de0951658b06002dc0c7388c4578
Signed-off-by: Praveen Chaudhary pchaudhary@linkedin.com

skb->csum is updated incorrectly, when manipulation for NF_NAT_MANIP_SRC\DST
is done on IPV6 packet.

Fix:
There is no need to update skb->csum in inet_proto_csum_replace16(), because
update in two fields a.) IPv6 src/dst address and b.) L4 header checksum
cancels each other for skb->csum calculation.
Whereas inet_proto_csum_replace4 function needs to update skb->csum,
because update in 3 fields a.) IPv4 src/dst address, b.) IPv4 Header checksum
and c.) L4 header checksum results in same diff as L4 Header checksum for
skb->csum calculation.

Signed-off-by: Praveen Chaudhary <pchaudhary@linkedin.com>
Signed-off-by: Zhenggen Xu <zxu@linkedin.com>
Signed-off-by: Andy Stracner <astracner@linkedin.com>

Reviewed-by: Florian Westphal <fw@strlen.de>
---
 net/core/utils.c | 22 +++++++++++++++++++---
 1 file changed, 19 insertions(+), 3 deletions(-)

diff --git a/net/core/utils.c b/net/core/utils.c
index 6b6e51d..e2f8290 100644
--- a/net/core/utils.c
+++ b/net/core/utils.c
@@ -438,6 +438,25 @@ void inet_proto_csum_replace4(__sum16 *sum, struct sk_buff *skb,
 }
 EXPORT_SYMBOL(inet_proto_csum_replace4);
 
+/**
+ * inet_proto_csum_replace16 - update L4 header checksum field as per the
+ * update in IPv6 src/dst address.
+ * Note: there is no need to update skb->csum in this function, because
+ * update in two fields a.) IPv6 src/dst address and b.) L4 header checksum
+ * cancels each other for skb->csum calculation.
+ * Whereas inet_proto_csum_replace4 function needs to update skb->csum,
+ * because update in 3 fields a.) IPv4 src/dst address, b.) IPv4 Header checksum
+ * and c.) L4 header checksum results in same diff as L4 Header checksum for
+ * skb->csum calculation.
+ *
+ * @sum: L4 header checksum field
+ * @skb: sk_buff for the packet
+ * @from: old IPv6 address
+ * @to: new IPv6 address
+ * @pseudohdr: True if L4 header checksum includes pseudoheader
+ *
+ * Return void
+ */
 void inet_proto_csum_replace16(__sum16 *sum, struct sk_buff *skb,
 			       const __be32 *from, const __be32 *to,
 			       bool pseudohdr)
@@ -449,9 +468,6 @@ void inet_proto_csum_replace16(__sum16 *sum, struct sk_buff *skb,
 	if (skb->ip_summed != CHECKSUM_PARTIAL) {
 		*sum = csum_fold(csum_partial(diff, sizeof(diff),
 				 ~csum_unfold(*sum)));
-		if (skb->ip_summed == CHECKSUM_COMPLETE && pseudohdr)
-			skb->csum = ~csum_partial(diff, sizeof(diff),
-						  ~skb->csum);
 	} else if (pseudohdr)
 		*sum = ~csum_fold(csum_partial(diff, sizeof(diff),
 				  csum_unfold(*sum)));
-- 


Testing:

Built kernel image with this patch. Snippet below:

```
Importing patch "net-backport-ipv6-missing-route.patch" ... done
Importing patch "Support-for-fullcone-nat.patch" ... <stdin>:251: space before tab in indent.
                        net_eq(net, nf_ct_net(ct)) &&
<stdin>:252: space before tab in indent.
                        nf_ct_zone_equal(ct, zone, IP_CT_DIR_ORIGINAL)) {
<stdin>:363: space before tab in indent.
                                                orig_tuple, tuple)) {
<stdin>:371: trailing whitespace.
                        }
warning: 4 lines add whitespace errors.
done
Importing patch "driver-ixgbe-external-phy.patch" ... done
Importing patch "fix_ismt_alignment_issue.patch" ... done
Importing patch "net-fix-skb-csum-update-in-inet_proto_csum_replace16.patch" ... done
Now at patch "net-fix-skb-csum-update-in-inet_proto_csum_replace16.patch"
make[1]: Entering directory '/home/pchaudha/srcCode/azure_dpb_merge/src/sonic-linux-kernel/linux-4.9.189'
dh_testdir
make -f debian/rules.gen binary-indep
make[2]: Entering directory '/home/pchaudha/srcCode/azure_dpb_merge/src/sonic-linux-kernel/linux-4.9.189'
make -f debian/rules.real binary-indep-featureset ABINAME='4.9.0-11-2' ALL_KERNEL_ARCHES='alpha arm arm64 m68k mips parisc powerpc s390 sh sparc x86' FEATURESET='none' LOCALVERSION='' SOURCEVERSION='4.9.189-3+deb9u2' UPSTREAMVERSION='4.9' VERSION='4.9'
make[3]: Entering directory '/home/pchaudha/srcCode/azure_dpb_merge/src/sonic-linux-kernel/linux-4.9.189'
dh_testdir
dh_testroot
dh_prep
set -o pipefail; \
cd debian/build/source_none; \
( \
        echo Makefile; \
        for arch in alpha arm arm64 m68k mips parisc powerpc s390 sh sparc x86; do \
                find arch/$arch -maxdepth 1 -name 'Makefile*' -print; \
                find arch/$arch \( -name 'module.lds' -o -name 'Kbuild.platforms' -o -name 'Platform' \) -print; \
                find $(find arch/$arch \( -name include -o -name scripts \) -type d -print) -print; \
```