### PR TITLE
Fix regulator issue on max6658 on buster

### DIFF
--- a/patch/driver-hwmon-max6658-bypass-regulator-error.patch
+++ b/patch/driver-hwmon-max6658-bypass-regulator-error.patch
@@ -1,0 +1,34 @@
+diff --git a/drivers/hwmon/lm90.c b/drivers/hwmon/lm90.c
+index 9d1a68d99..55c8913a4 100644
+--- a/drivers/hwmon/lm90.c
++++ b/drivers/hwmon/lm90.c
+@@ -1793,19 +1793,19 @@ static int lm90_probe(struct i2c_client *client,
+ 	int err;
+ 
+ 	regulator = devm_regulator_get(dev, "vcc");
+-	if (IS_ERR(regulator))
+-		return PTR_ERR(regulator);
++	if (!IS_ERR(regulator)){
++		err = regulator_enable(regulator);
++		if (err < 0) {
++			dev_err(dev, "Failed to enable regulator: %d\n", err);
++			return err;
++		}
+ 
+-	err = regulator_enable(regulator);
+-	if (err < 0) {
+-		dev_err(dev, "Failed to enable regulator: %d\n", err);
+-		return err;
++		err = devm_add_action_or_reset(dev, lm90_regulator_disable,
++					       regulator);
++		if (err)
++			return err;
+ 	}
+ 
+-	err = devm_add_action_or_reset(dev, lm90_regulator_disable, regulator);
+-	if (err)
+-		return err;
+-
+ 	data = devm_kzalloc(dev, sizeof(struct lm90_data), GFP_KERNEL);
+ 	if (!data)
+ 		return -ENOMEM;

--- a/patch/series
+++ b/patch/series
@@ -19,6 +19,7 @@ driver-hwmon-max6620.patch
 driver-hwmon-max6620-fix-rpm-calc.patch
 driver-hwmon-max6620-update.patch
 driver-hwmon-max6658-fix-write-convrate.patch
+driver-hwmon-max6658-bypass-regulator-error.patch
 driver-hwmon-pmbus-dni_dps460.patch
 driver-hwmon-pmbus-dni_dps460-update-pmbus-core.patch
 driver-hwmon-pmbus-dps1900.patch


### PR DESCRIPTION
CONFIG_REGULATOR is enabled by default on buster kernel.  With such change, devm_regulator_get() starts to return error code on the Arista 7050, which is also related to acpi=off being set on the platform. This fix is to ignore the error to keep max6658 initialized.