### PR TITLE
[Patch] Armada i2c driver

### DIFF
--- a/patch/0042-armhf-additional-configs.patch
+++ b/patch/0042-armhf-additional-configs.patch
@@ -85,5 +85,82 @@ index e997934..69288eb 100644
  # CONFIG_SENSORS_MAX6697 is not set
  # CONFIG_SENSORS_MAX31790 is not set
  # CONFIG_SENSORS_MCP3021 is not set
-2.7.4
-
+diff --git a/debian/build/build_armhf_none_armmp/.config b/debian/build/build_armhf_none_armmp/.config
+index e997934..69288eb 100644
+--- a/debian/build/build_armhf_none_armmp/.config
++++ b/debian/build/build_armhf_none_armmp/.config
+@@ -3390,7 +3390,7 @@
+ # Multiplexer I2C Chip support
+ #
+ CONFIG_I2C_ARB_GPIO_CHALLENGE=m
+-# CONFIG_I2C_MUX_GPIO is not set
++CONFIG_I2C_MUX_GPIO=m
+ # CONFIG_I2C_MUX_PCA9541 is not set
+ CONFIG_I2C_MUX_PCA954x=m
+ # CONFIG_I2C_MUX_PINCTRL is not set
+diff --git a/drivers/i2c/busses/i2c-mv64xxx.c b/drivers/i2c/busses/i2c-mv64xxx.c
+index 5c9dea7..c4e6c19 100644
+--- a/drivers/i2c/busses/i2c-mv64xxx.c
++++ b/drivers/i2c/busses/i2c-mv64xxx.c
+@@ -25,6 +25,7 @@
+ #include <linux/clk.h>
+ #include <linux/err.h>
+ #include <linux/delay.h>
++#include <linux/semaphore.h>
+ 
+ #define MV64XXX_I2C_ADDR_ADDR(val)			((val & 0x7f) << 1)
+ #define MV64XXX_I2C_BAUD_DIV_N(val)			(val & 0x7)
+@@ -146,6 +147,7 @@
+ 	bool			irq_clear_inverted;
+ 	/* Clk div is 2 to the power n, not 2 to the power n + 1 */
+ 	bool			clk_n_base_0;
++        struct semaphore        sem_lock;
+ };
+ 
+ static struct mv64xxx_i2c_regs mv64xxx_i2c_regs_mv64xxx = {
+@@ -718,6 +720,9 @@
+ 	drv_data->msgs = msgs;
+ 	drv_data->num_msgs = num;
+ 
++        if (down_interruptible(&drv_data->sem_lock)){
++            return(-EINTR);
++        }
+ 	if (mv64xxx_i2c_can_offload(drv_data))
+ 		rc = mv64xxx_i2c_offload_xfer(drv_data);
+ 	else
+@@ -725,6 +730,7 @@
+ 
+ 	if (rc < 0)
+ 		ret = rc;
++        up(&drv_data->sem_lock);
+ 
+ 	drv_data->num_msgs = 0;
+ 	drv_data->msgs = NULL;
+@@ -863,6 +869,8 @@
+ 	if (of_device_is_compatible(np, "allwinner,sun6i-a31-i2c"))
+ 		drv_data->irq_clear_inverted = true;
+ 
++        dev_info(&drv_data->adapter.dev,
++                "mv64xxx: i2c adapter, clock: %dHz\n", bus_freq);
+ out:
+ 	return rc;
+ }
+@@ -901,6 +909,7 @@
+ 
+ 	init_waitqueue_head(&drv_data->waitq);
+ 	spin_lock_init(&drv_data->lock);
++	sema_init(&drv_data->sem_lock, 1);
+ 
+ 	/* Not all platforms have a clk */
+ 	drv_data->clk = devm_clk_get(&pd->dev, NULL);
+@@ -949,6 +958,8 @@
+ 			"mv64xxx: Can't add i2c adapter, rc: %d\n", -rc);
+ 		goto exit_free_irq;
+ 	}
++        dev_info(&drv_data->adapter.dev,
++                "mv64xxx: i2c adapter, sema version\n");
+ 
+ 	return 0;
+ 
+-- 
+2.18.0


### PR DESCRIPTION
Enabled i2C MUX for GPIO
Safe protection lock for i2c transaction

Signed-off-by: Antony Rheneus <arheneus@marvell.com>