### PR TITLE
Add Backward porting the I2C ocores controller driver from kernel ups…

### DIFF
--- a/patch/driver-i2c-ocores-5-1.patch
+++ b/patch/driver-i2c-ocores-5-1.patch
@@ -1,0 +1,540 @@
+Add Backward porting the I2C ocores controller driver from kernel upstream version 5.1 to 4.19.
+
+Containing upstream patches:
+- e7663ef i2c: ocores: stop transfer on timeout
+- 2dc9834 i2c: ocores: do not handle IRQ if IF is not set
+- 69c8c0c i2c: ocores: add polling interface
+- 2c7e492 i2c: ocores: add SPDX tag
+- fac9c29 i2c: ocores: checkpatch fixes
+- 809445d i2c: ocores: Add support for IO mapper registers
+- 237b5f6 i2c: ocores: Add support for bus clock via platform data
+- 088a8a7 i2c: ocores: turn incomplete kdoc into a comment
+
+Signed-off-by: Jakkapan Jangmuang <jjangmua@celestica.com>
+---
+
+diff --git a/drivers/i2c/busses/i2c-ocores.c b/drivers/i2c/busses/i2c-ocores.c
+index 87f9caacb..4e1a077fb 100644
+--- a/drivers/i2c/busses/i2c-ocores.c
++++ b/drivers/i2c/busses/i2c-ocores.c
+@@ -1,3 +1,4 @@
++// SPDX-License-Identifier: GPL-2.0
+ /*
+  * i2c-ocores.c: I2C bus driver for OpenCores I2C controller
+  * (https://opencores.org/project/i2c/overview)
+@@ -6,13 +7,10 @@
+  *
+  * Support for the GRLIB port of the controller by
+  * Andreas Larsson <andreas@gaisler.com>
+- *
+- * This file is licensed under the terms of the GNU General Public License
+- * version 2.  This program is licensed "as is" without any warranty of any
+- * kind, whether express or implied.
+  */
+ 
+ #include <linux/clk.h>
++#include <linux/delay.h>
+ #include <linux/err.h>
+ #include <linux/kernel.h>
+ #include <linux/module.h>
+@@ -25,17 +23,28 @@
+ #include <linux/slab.h>
+ #include <linux/io.h>
+ #include <linux/log2.h>
++#include <linux/spinlock.h>
++#include <linux/jiffies.h>
++
++#define OCORES_FLAG_POLL BIT(0)
+ 
++/*
++ * 'process_lock' exists because ocores_process() and ocores_process_timeout()
++ * can't run in parallel.
++ */
+ struct ocores_i2c {
+ 	void __iomem *base;
++	int iobase;
+ 	u32 reg_shift;
+ 	u32 reg_io_width;
++	unsigned long flags;
+ 	wait_queue_head_t wait;
+ 	struct i2c_adapter adap;
+ 	struct i2c_msg *msg;
+ 	int pos;
+ 	int nmsgs;
+ 	int state; /* see STATE_ */
++	spinlock_t process_lock;
+ 	struct clk *clk;
+ 	int ip_clock_khz;
+ 	int bus_clock_khz;
+@@ -127,6 +136,16 @@ static inline u8 oc_getreg_32be(struct ocores_i2c *i2c, int reg)
+ 	return ioread32be(i2c->base + (reg << i2c->reg_shift));
+ }
+ 
++static void oc_setreg_io_8(struct ocores_i2c *i2c, int reg, u8 value)
++{
++	outb(value, i2c->iobase + reg);
++}
++
++static inline u8 oc_getreg_io_8(struct ocores_i2c *i2c, int reg)
++{
++	return inb(i2c->iobase + reg);
++}
++
+ static inline void oc_setreg(struct ocores_i2c *i2c, int reg, u8 value)
+ {
+ 	i2c->setreg(i2c, reg, value);
+@@ -137,23 +156,29 @@ static inline u8 oc_getreg(struct ocores_i2c *i2c, int reg)
+ 	return i2c->getreg(i2c, reg);
+ }
+ 
+-static void ocores_process(struct ocores_i2c *i2c)
++static void ocores_process(struct ocores_i2c *i2c, u8 stat)
+ {
+ 	struct i2c_msg *msg = i2c->msg;
+-	u8 stat = oc_getreg(i2c, OCI2C_STATUS);
++	unsigned long flags;
++
++	/*
++	 * If we spin here is because we are in timeout, so we are going
++	 * to be in STATE_ERROR. See ocores_process_timeout()
++	 */
++	spin_lock_irqsave(&i2c->process_lock, flags);
+ 
+ 	if ((i2c->state == STATE_DONE) || (i2c->state == STATE_ERROR)) {
+ 		/* stop has been sent */
+ 		oc_setreg(i2c, OCI2C_CMD, OCI2C_CMD_IACK);
+ 		wake_up(&i2c->wait);
+-		return;
++		goto out;
+ 	}
+ 
+ 	/* error? */
+ 	if (stat & OCI2C_STAT_ARBLOST) {
+ 		i2c->state = STATE_ERROR;
+ 		oc_setreg(i2c, OCI2C_CMD, OCI2C_CMD_STOP);
+-		return;
++		goto out;
+ 	}
+ 
+ 	if ((i2c->state == STATE_START) || (i2c->state == STATE_WRITE)) {
+@@ -163,10 +188,11 @@ static void ocores_process(struct ocores_i2c *i2c)
+ 		if (stat & OCI2C_STAT_NACK) {
+ 			i2c->state = STATE_ERROR;
+ 			oc_setreg(i2c, OCI2C_CMD, OCI2C_CMD_STOP);
+-			return;
++			goto out;
+ 		}
+-	} else
++	} else {
+ 		msg->buf[i2c->pos++] = oc_getreg(i2c, OCI2C_DATA);
++	}
+ 
+ 	/* end of msg? */
+ 	if (i2c->pos == msg->len) {
+@@ -183,15 +209,15 @@ static void ocores_process(struct ocores_i2c *i2c)
+ 				i2c->state = STATE_START;
+ 
+ 				oc_setreg(i2c, OCI2C_DATA, addr);
+-				oc_setreg(i2c, OCI2C_CMD,  OCI2C_CMD_START);
+-				return;
+-			} else
+-				i2c->state = (msg->flags & I2C_M_RD)
+-					? STATE_READ : STATE_WRITE;
++				oc_setreg(i2c, OCI2C_CMD, OCI2C_CMD_START);
++				goto out;
++			}
++			i2c->state = (msg->flags & I2C_M_RD)
++				? STATE_READ : STATE_WRITE;
+ 		} else {
+ 			i2c->state = STATE_DONE;
+ 			oc_setreg(i2c, OCI2C_CMD, OCI2C_CMD_STOP);
+-			return;
++			goto out;
+ 		}
+ 	}
+ 
+@@ -202,20 +228,148 @@ static void ocores_process(struct ocores_i2c *i2c)
+ 		oc_setreg(i2c, OCI2C_DATA, msg->buf[i2c->pos++]);
+ 		oc_setreg(i2c, OCI2C_CMD, OCI2C_CMD_WRITE);
+ 	}
++
++out:
++	spin_unlock_irqrestore(&i2c->process_lock, flags);
+ }
+ 
+ static irqreturn_t ocores_isr(int irq, void *dev_id)
+ {
+ 	struct ocores_i2c *i2c = dev_id;
++	u8 stat = oc_getreg(i2c, OCI2C_STATUS);
++
++	if (!(stat & OCI2C_STAT_IF))
++		return IRQ_NONE;
+ 
+-	ocores_process(i2c);
++	ocores_process(i2c, stat);
+ 
+ 	return IRQ_HANDLED;
+ }
+ 
+-static int ocores_xfer(struct i2c_adapter *adap, struct i2c_msg *msgs, int num)
++/**
++ * Process timeout event
++ * @i2c: ocores I2C device instance
++ */
++static void ocores_process_timeout(struct ocores_i2c *i2c)
+ {
+-	struct ocores_i2c *i2c = i2c_get_adapdata(adap);
++	unsigned long flags;
++
++	spin_lock_irqsave(&i2c->process_lock, flags);
++	i2c->state = STATE_ERROR;
++	oc_setreg(i2c, OCI2C_CMD, OCI2C_CMD_STOP);
++	spin_unlock_irqrestore(&i2c->process_lock, flags);
++}
++
++/**
++ * Wait until something change in a given register
++ * @i2c: ocores I2C device instance
++ * @reg: register to query
++ * @mask: bitmask to apply on register value
++ * @val: expected result
++ * @timeout: timeout in jiffies
++ *
++ * Timeout is necessary to avoid to stay here forever when the chip
++ * does not answer correctly.
++ *
++ * Return: 0 on success, -ETIMEDOUT on timeout
++ */
++static int ocores_wait(struct ocores_i2c *i2c,
++		       int reg, u8 mask, u8 val,
++		       const unsigned long timeout)
++{
++	unsigned long j;
++
++	j = jiffies + timeout;
++	while (1) {
++		u8 status = oc_getreg(i2c, reg);
++
++		if ((status & mask) == val)
++			break;
++
++		if (time_after(jiffies, j))
++			return -ETIMEDOUT;
++	}
++	return 0;
++}
++
++/**
++ * Wait until is possible to process some data
++ * @i2c: ocores I2C device instance
++ *
++ * Used when the device is in polling mode (interrupts disabled).
++ *
++ * Return: 0 on success, -ETIMEDOUT on timeout
++ */
++static int ocores_poll_wait(struct ocores_i2c *i2c)
++{
++	u8 mask;
++	int err;
++
++	if (i2c->state == STATE_DONE || i2c->state == STATE_ERROR) {
++		/* transfer is over */
++		mask = OCI2C_STAT_BUSY;
++	} else {
++		/* on going transfer */
++		mask = OCI2C_STAT_TIP;
++		/*
++		 * We wait for the data to be transferred (8bit),
++		 * then we start polling on the ACK/NACK bit
++		 */
++		udelay((8 * 1000) / i2c->bus_clock_khz);
++	}
++
++	/*
++	 * once we are here we expect to get the expected result immediately
++	 * so if after 1ms we timeout then something is broken.
++	 */
++	err = ocores_wait(i2c, OCI2C_STATUS, mask, 0, msecs_to_jiffies(1));
++	if (err)
++		dev_warn(i2c->adap.dev.parent,
++			 "%s: STATUS timeout, bit 0x%x did not clear in 1ms\n",
++			 __func__, mask);
++	return err;
++}
++
++/**
++ * It handles an IRQ-less transfer
++ * @i2c: ocores I2C device instance
++ *
++ * Even if IRQ are disabled, the I2C OpenCore IP behavior is exactly the same
++ * (only that IRQ are not produced). This means that we can re-use entirely
++ * ocores_isr(), we just add our polling code around it.
++ *
++ * It can run in atomic context
++ */
++static void ocores_process_polling(struct ocores_i2c *i2c)
++{
++	while (1) {
++		irqreturn_t ret;
++		int err;
++
++		err = ocores_poll_wait(i2c);
++		if (err) {
++			i2c->state = STATE_ERROR;
++			break; /* timeout */
++		}
++
++		ret = ocores_isr(-1, i2c);
++		if (ret == IRQ_NONE)
++			break; /* all messages have been transferred */
++	}
++}
++
++static int ocores_xfer_core(struct ocores_i2c *i2c,
++			    struct i2c_msg *msgs, int num,
++			    bool polling)
++{
++	int ret;
++	u8 ctrl;
++
++	ctrl = oc_getreg(i2c, OCI2C_CONTROL);
++	if (polling)
++		oc_setreg(i2c, OCI2C_CONTROL, ctrl & ~OCI2C_CTRL_IEN);
++	else
++		oc_setreg(i2c, OCI2C_CONTROL, ctrl | OCI2C_CTRL_IEN);
+ 
+ 	i2c->msg = msgs;
+ 	i2c->pos = 0;
+@@ -225,11 +379,35 @@ static int ocores_xfer(struct i2c_adapter *adap, struct i2c_msg *msgs, int num)
+ 	oc_setreg(i2c, OCI2C_DATA, i2c_8bit_addr_from_msg(i2c->msg));
+ 	oc_setreg(i2c, OCI2C_CMD, OCI2C_CMD_START);
+ 
+-	if (wait_event_timeout(i2c->wait, (i2c->state == STATE_ERROR) ||
+-			       (i2c->state == STATE_DONE), HZ))
+-		return (i2c->state == STATE_DONE) ? num : -EIO;
+-	else
+-		return -ETIMEDOUT;
++	if (polling) {
++		ocores_process_polling(i2c);
++	} else {
++		ret = wait_event_timeout(i2c->wait,
++					 (i2c->state == STATE_ERROR) ||
++					 (i2c->state == STATE_DONE), HZ);
++		if (ret == 0) {
++			ocores_process_timeout(i2c);
++			return -ETIMEDOUT;
++		}
++	}
++
++	return (i2c->state == STATE_DONE) ? num : -EIO;
++}
++
++static int ocores_xfer_polling(struct i2c_adapter *adap,
++			       struct i2c_msg *msgs, int num)
++{
++	return ocores_xfer_core(i2c_get_adapdata(adap), msgs, num, true);
++}
++
++static int ocores_xfer(struct i2c_adapter *adap,
++		       struct i2c_msg *msgs, int num)
++{
++	struct ocores_i2c *i2c = i2c_get_adapdata(adap);
++
++	if (i2c->flags & OCORES_FLAG_POLL)
++		return ocores_xfer_polling(adap, msgs, num);
++	return ocores_xfer_core(i2c, msgs, num, false);
+ }
+ 
+ static int ocores_init(struct device *dev, struct ocores_i2c *i2c)
+@@ -239,7 +417,8 @@ static int ocores_init(struct device *dev, struct ocores_i2c *i2c)
+ 	u8 ctrl = oc_getreg(i2c, OCI2C_CONTROL);
+ 
+ 	/* make sure the device is disabled */
+-	oc_setreg(i2c, OCI2C_CONTROL, ctrl & ~(OCI2C_CTRL_EN|OCI2C_CTRL_IEN));
++	ctrl &= ~(OCI2C_CTRL_EN | OCI2C_CTRL_IEN);
++	oc_setreg(i2c, OCI2C_CONTROL, ctrl);
+ 
+ 	prescale = (i2c->ip_clock_khz / (5 * i2c->bus_clock_khz)) - 1;
+ 	prescale = clamp(prescale, 0, 0xffff);
+@@ -257,7 +436,7 @@ static int ocores_init(struct device *dev, struct ocores_i2c *i2c)
+ 
+ 	/* Init the device */
+ 	oc_setreg(i2c, OCI2C_CMD, OCI2C_CMD_IACK);
+-	oc_setreg(i2c, OCI2C_CONTROL, ctrl | OCI2C_CTRL_IEN | OCI2C_CTRL_EN);
++	oc_setreg(i2c, OCI2C_CONTROL, ctrl | OCI2C_CTRL_EN);
+ 
+ 	return 0;
+ }
+@@ -294,13 +473,16 @@ static const struct of_device_id ocores_i2c_match[] = {
+ MODULE_DEVICE_TABLE(of, ocores_i2c_match);
+ 
+ #ifdef CONFIG_OF
+-/* Read and write functions for the GRLIB port of the controller. Registers are
++/*
++ * Read and write functions for the GRLIB port of the controller. Registers are
+  * 32-bit big endian and the PRELOW and PREHIGH registers are merged into one
+- * register. The subsequent registers has their offset decreased accordingly. */
++ * register. The subsequent registers have their offsets decreased accordingly.
++ */
+ static u8 oc_getreg_grlib(struct ocores_i2c *i2c, int reg)
+ {
+ 	u32 rd;
+ 	int rreg = reg;
++
+ 	if (reg != OCI2C_PRELOW)
+ 		rreg--;
+ 	rd = ioread32be(i2c->base + (rreg << i2c->reg_shift));
+@@ -314,6 +496,7 @@ static void oc_setreg_grlib(struct ocores_i2c *i2c, int reg, u8 value)
+ {
+ 	u32 curr, wr;
+ 	int rreg = reg;
++
+ 	if (reg != OCI2C_PRELOW)
+ 		rreg--;
+ 	if (reg == OCI2C_PRELOW || reg == OCI2C_PREHIGH) {
+@@ -402,7 +585,7 @@ static int ocores_i2c_of_probe(struct platform_device *pdev,
+ 	return 0;
+ }
+ #else
+-#define ocores_i2c_of_probe(pdev,i2c) -ENODEV
++#define ocores_i2c_of_probe(pdev, i2c) -ENODEV
+ #endif
+ 
+ static int ocores_i2c_probe(struct platform_device *pdev)
+@@ -414,25 +597,41 @@ static int ocores_i2c_probe(struct platform_device *pdev)
+ 	int ret;
+ 	int i;
+ 
+-	irq = platform_get_irq(pdev, 0);
+-	if (irq < 0)
+-		return irq;
+-
+ 	i2c = devm_kzalloc(&pdev->dev, sizeof(*i2c), GFP_KERNEL);
+ 	if (!i2c)
+ 		return -ENOMEM;
+ 
++	spin_lock_init(&i2c->process_lock);
++
+ 	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
+-	i2c->base = devm_ioremap_resource(&pdev->dev, res);
+-	if (IS_ERR(i2c->base))
+-		return PTR_ERR(i2c->base);
++	if (res) {
++		i2c->base = devm_ioremap_resource(&pdev->dev, res);
++		if (IS_ERR(i2c->base))
++			return PTR_ERR(i2c->base);
++	} else {
++		res = platform_get_resource(pdev, IORESOURCE_IO, 0);
++		if (!res)
++			return -EINVAL;
++		i2c->iobase = res->start;
++		if (!devm_request_region(&pdev->dev, res->start,
++					 resource_size(res),
++					 pdev->name)) {
++			dev_err(&pdev->dev, "Can't get I/O resource.\n");
++			return -EBUSY;
++		}
++		i2c->setreg = oc_setreg_io_8;
++		i2c->getreg = oc_getreg_io_8;
++	}
+ 
+ 	pdata = dev_get_platdata(&pdev->dev);
+ 	if (pdata) {
+ 		i2c->reg_shift = pdata->reg_shift;
+ 		i2c->reg_io_width = pdata->reg_io_width;
+ 		i2c->ip_clock_khz = pdata->clock_khz;
+-		i2c->bus_clock_khz = 100;
++		if (pdata->bus_khz)
++			i2c->bus_clock_khz = pdata->bus_khz;
++		else
++			i2c->bus_clock_khz = 100;
+ 	} else {
+ 		ret = ocores_i2c_of_probe(pdev, i2c);
+ 		if (ret)
+@@ -470,18 +669,29 @@ static int ocores_i2c_probe(struct platform_device *pdev)
+ 		}
+ 	}
+ 
++	init_waitqueue_head(&i2c->wait);
++
++	irq = platform_get_irq(pdev, 0);
++	if (irq == -ENXIO) {
++		i2c->flags |= OCORES_FLAG_POLL;
++	} else {
++		if (irq < 0)
++			return irq;
++	}
++
++	if (!(i2c->flags & OCORES_FLAG_POLL)) {
++		ret = devm_request_irq(&pdev->dev, irq, ocores_isr, 0,
++				       pdev->name, i2c);
++		if (ret) {
++			dev_err(&pdev->dev, "Cannot claim IRQ\n");
++			goto err_clk;
++		}
++	}
++
+ 	ret = ocores_init(&pdev->dev, i2c);
+ 	if (ret)
+ 		goto err_clk;
+ 
+-	init_waitqueue_head(&i2c->wait);
+-	ret = devm_request_irq(&pdev->dev, irq, ocores_isr, 0,
+-			       pdev->name, i2c);
+-	if (ret) {
+-		dev_err(&pdev->dev, "Cannot claim IRQ\n");
+-		goto err_clk;
+-	}
+-
+ 	/* hook up driver to tree */
+ 	platform_set_drvdata(pdev, i2c);
+ 	i2c->adap = ocores_adapter;
+@@ -510,10 +720,11 @@ static int ocores_i2c_probe(struct platform_device *pdev)
+ static int ocores_i2c_remove(struct platform_device *pdev)
+ {
+ 	struct ocores_i2c *i2c = platform_get_drvdata(pdev);
++	u8 ctrl = oc_getreg(i2c, OCI2C_CONTROL);
+ 
+ 	/* disable i2c logic */
+-	oc_setreg(i2c, OCI2C_CONTROL, oc_getreg(i2c, OCI2C_CONTROL)
+-		  & ~(OCI2C_CTRL_EN|OCI2C_CTRL_IEN));
++	ctrl &= ~(OCI2C_CTRL_EN | OCI2C_CTRL_IEN);
++	oc_setreg(i2c, OCI2C_CONTROL, ctrl);
+ 
+ 	/* remove adapter & data */
+ 	i2c_del_adapter(&i2c->adap);
+@@ -531,7 +742,8 @@ static int ocores_i2c_suspend(struct device *dev)
+ 	u8 ctrl = oc_getreg(i2c, OCI2C_CONTROL);
+ 
+ 	/* make sure the device is disabled */
+-	oc_setreg(i2c, OCI2C_CONTROL, ctrl & ~(OCI2C_CTRL_EN|OCI2C_CTRL_IEN));
++	ctrl &= ~(OCI2C_CTRL_EN | OCI2C_CTRL_IEN);
++	oc_setreg(i2c, OCI2C_CONTROL, ctrl);
+ 
+ 	if (!IS_ERR(i2c->clk))
+ 		clk_disable_unprepare(i2c->clk);
+diff --git a/include/linux/platform_data/i2c-ocores.h b/include/linux/platform_data/i2c-ocores.h
+index 113d6b12f..e6326cbaf 100644
+--- a/include/linux/platform_data/i2c-ocores.h
++++ b/include/linux/platform_data/i2c-ocores.h
+@@ -1,11 +1,8 @@
++/* SPDX-License-Identifier: GPL-2.0 */
+ /*
+  * i2c-ocores.h - definitions for the i2c-ocores interface
+  *
+  * Peter Korsgaard <peter@korsgaard.com>
+- *
+- * This file is licensed under the terms of the GNU General Public License
+- * version 2.  This program is licensed "as is" without any warranty of any
+- * kind, whether express or implied.
+  */
+ 
+ #ifndef _LINUX_I2C_OCORES_H
+@@ -15,6 +12,7 @@ struct ocores_i2c_platform_data {
+ 	u32 reg_shift; /* register offset shift value */
+ 	u32 reg_io_width; /* register io read/write width */
+ 	u32 clock_khz; /* input clock in kHz */
++	u32 bus_khz; /* bus clock in kHz */
+ 	bool big_endian; /* registers are big endian */
+ 	u8 num_devices; /* number of devices in the devices list */
+ 	struct i2c_board_info const *devices; /* devices connected to the bus */

--- a/patch/series
+++ b/patch/series
@@ -13,6 +13,7 @@ driver-sff-8436-use-nvmem-framework.patch
 driver-sff-8436-use-nvmem_device_read.patch
 driver-support-sff-8436-read-write-fix.patch
 driver-i2c-bus-intel-ismt-add-delay-param.patch
+driver-i2c-ocores-5-1.patch
 driver-pca954x-i2c-mux-force-deselect-on-exit-flag.patch
 kernel-add-kexec-reboot-string.patch
 driver-hwmon-max6620.patch


### PR DESCRIPTION
Add backward porting the I2C ocores controller driver from kernel upstream version 5.1 to 4.19.

Containing upstream patches:
- e7663ef i2c: ocores: stop transfer on timeout
- 2dc9834 i2c: ocores: do not handle IRQ if IF is not set
- 69c8c0c i2c: ocores: add polling interface
- 2c7e492 i2c: ocores: add SPDX tag
- fac9c29 i2c: ocores: checkpatch fixes
- 809445d i2c: ocores: Add support for IO mapper registers
- 237b5f6 i2c: ocores: Add support for bus clock via platform data
- 088a8a7 i2c: ocores: turn incomplete kdoc into a comment