### PR TITLE
[Mellanox] Fix issue: thermal algorithm not work on SN4700

### DIFF
--- a/patch/0011-mlxsw-core-thermal-Separate-temperature-trend-read-c.patch
+++ b/patch/0011-mlxsw-core-thermal-Separate-temperature-trend-read-c.patch
@@ -1,0 +1,80 @@
+From b3fb34f9f6215e0677de88e07f2139b56ba7508f Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@mellanox.com>
+Date: Thu, 21 May 2020 13:34:17 +0300
+Subject: [backport 4.19 2/3] mlxsw: core: thermal: Separate temperature trend
+ read callback
+
+Separate temperature trend reading callback between chip thermal zone
+and others types of thermal zones (modules and gearboxes).
+Currently all these types use same get_trend() callback, which is wrong for
+the chip thermal zone, which is defined as "parent zone".
+When get_trend() callback is invoked, it obtains "parent zone" from the
+relevant thermal device data, which is correct for modules and
+gearboxes thermal devices, but not for chip thermal device, which is
+a parent.
+Keep using the existing get_trend() callback for modules and gearboxes,
+add new get_trend() callback for chip.
+
+Signed-off-by: Vadim Pasternak <vadimp@mellanox.com>
+---
+ drivers/net/ethernet/mellanox/mlxsw/core_thermal.c | 23 ++++++++++++++++++----
+ 1 file changed, 19 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c b/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
+index 77578f5bb..775343a25 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
++++ b/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
+@@ -402,8 +402,7 @@ static int mlxsw_thermal_set_trip_hyst(struct thermal_zone_device *tzdev,
+ static int mlxsw_thermal_trend_get(struct thermal_zone_device *tzdev,
+ 				   int trip, enum thermal_trend *trend)
+ {
+-	struct mlxsw_thermal_module *tz = tzdev->devdata;
+-	struct mlxsw_thermal *thermal = tz->parent;
++	struct mlxsw_thermal *thermal = tzdev->devdata;
+ 
+ 	if (trip < 0 || trip >= MLXSW_THERMAL_NUM_TRIPS)
+ 		return -EINVAL;
+@@ -614,6 +613,22 @@ mlxsw_thermal_module_trip_hyst_set(struct thermal_zone_device *tzdev, int trip,
+ 	return 0;
+ }
+ 
++static int mlxsw_thermal_module_trend_get(struct thermal_zone_device *tzdev,
++					  int trip, enum thermal_trend *trend)
++{
++	struct mlxsw_thermal_module *tz = tzdev->devdata;
++	struct mlxsw_thermal *thermal = tz->parent;
++
++	if (trip < 0 || trip >= MLXSW_THERMAL_NUM_TRIPS)
++		return -EINVAL;
++
++	if (tzdev == thermal->tz_highest_dev)
++		return 1;
++
++	*trend = THERMAL_TREND_STABLE;
++	return 0;
++}
++
+ static struct thermal_zone_device_ops mlxsw_thermal_module_ops = {
+ 	.bind		= mlxsw_thermal_module_bind,
+ 	.unbind		= mlxsw_thermal_module_unbind,
+@@ -625,7 +640,7 @@ static struct thermal_zone_device_ops mlxsw_thermal_module_ops = {
+ 	.set_trip_temp	= mlxsw_thermal_module_trip_temp_set,
+ 	.get_trip_hyst	= mlxsw_thermal_module_trip_hyst_get,
+ 	.set_trip_hyst	= mlxsw_thermal_module_trip_hyst_set,
+-	.get_trend	= mlxsw_thermal_trend_get,
++	.get_trend	= mlxsw_thermal_module_trend_get,
+ };
+ 
+ static int mlxsw_thermal_gearbox_temp_get(struct thermal_zone_device *tzdev,
+@@ -670,7 +685,7 @@ static struct thermal_zone_device_ops mlxsw_thermal_gearbox_ops = {
+ 	.set_trip_temp	= mlxsw_thermal_module_trip_temp_set,
+ 	.get_trip_hyst	= mlxsw_thermal_module_trip_hyst_get,
+ 	.set_trip_hyst	= mlxsw_thermal_module_trip_hyst_set,
+-	.get_trend	= mlxsw_thermal_trend_get,
++	.get_trend	= mlxsw_thermal_module_trend_get,
+ };
+ 
+ static int mlxsw_thermal_get_max_state(struct thermal_cooling_device *cdev,
+-- 
+2.11.0
+

--- a/patch/series
+++ b/patch/series
@@ -78,4 +78,5 @@ net-fix-skb-csum-update-in-inet_proto_csum_replace16.patch
 0008-mlxsw-qsfp_sysfs-Remove-obsolete-code-for-QSFP-EEPRO.patch
 0009-platform-mellanox-mlxreg-io-Add-support-for-compl.patch
 0010-platform-mellanox-mlxreg-hotplug-Add-environmental-d.patch
+0011-mlxsw-core-thermal-Separate-temperature-trend-read-c.patch
 


### PR DESCRIPTION
Why I did this?

Thermal algorithm not work on SN4700

How I fix?

Create a patch for linux kernel to treat temperature trend for ASIC, modules and gearboxed separately.

How I verify?

Manual test on SN4700.
