### PR TITLE
[201911][Mellanox] Fix issue: thermal algorithm not work on SN4700

### DIFF
--- a/patch/0067-mlxsw-core-thermal-Separate-temperature-trend-read-c.patch
+++ b/patch/0067-mlxsw-core-thermal-Separate-temperature-trend-read-c.patch
@@ -1,0 +1,67 @@
+From bc61d729cb35aba4667b3278d4297d338bf19ffe Mon Sep 17 00:00:00 2001
+From: junchao <junchao@contoso.com>
+Date: Thu, 21 May 2020 00:45:04 +0000
+Subject: [backport 4.9] mlxsw: core: thermal: Separate temperature trend read
+ callback
+
+Separate temperature trend reading callback between chip thermal zone
+and others types of thermal zones (modules and gearboxes).
+Currently all these types use same get_trend() callback, which is wrong for
+the chip thermal zone, which is defined as "parent zone".
+When get_trend() callback is invoked, it obtains "parent zone" from the
+relevant thermal device data, which is correct for modules and
+gearboxes thermal devices, but not for chip thermal device, which is
+a parent.
+Keep using the existing get_trend() callback for modules and gearboxes,
+add new get_trend() callback for chip.
+
+---
+ drivers/net/ethernet/mellanox/mlxsw/core_thermal.c | 19 +++++++++++++++++--
+ 1 file changed, 17 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c b/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
+index 53198e2..f944b0f 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
++++ b/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
+@@ -402,6 +402,21 @@ static int mlxsw_thermal_set_trip_hyst(struct thermal_zone_device *tzdev,
+ static int mlxsw_thermal_trend_get(struct thermal_zone_device *tzdev,
+ 				   int trip, enum thermal_trend *trend)
+ {
++	struct mlxsw_thermal *thermal = tzdev->devdata;
++
++	if (trip < 0 || trip >= MLXSW_THERMAL_NUM_TRIPS)
++		return -EINVAL;
++
++	if (tzdev == thermal->tz_highest_dev)
++		return 1;
++
++	*trend = THERMAL_TREND_STABLE;
++	return 0;
++}
++
++static int mlxsw_thermal_module_trend_get(struct thermal_zone_device *tzdev,
++					  int trip, enum thermal_trend *trend)
++{
+ 	struct mlxsw_thermal_module *tz = tzdev->devdata;
+ 	struct mlxsw_thermal *thermal = tz->parent;
+ 
+@@ -625,7 +640,7 @@ static struct thermal_zone_device_ops mlxsw_thermal_module_ops = {
+ 	.set_trip_temp	= mlxsw_thermal_module_trip_temp_set,
+ 	.get_trip_hyst	= mlxsw_thermal_module_trip_hyst_get,
+ 	.set_trip_hyst	= mlxsw_thermal_module_trip_hyst_set,
+-	.get_trend	= mlxsw_thermal_trend_get,
++	.get_trend	= mlxsw_thermal_module_trend_get,
+ };
+ 
+ static int mlxsw_thermal_gearbox_temp_get(struct thermal_zone_device *tzdev,
+@@ -670,7 +685,7 @@ static struct thermal_zone_device_ops mlxsw_thermal_gearbox_ops = {
+ 	.set_trip_temp	= mlxsw_thermal_module_trip_temp_set,
+ 	.get_trip_hyst	= mlxsw_thermal_module_trip_hyst_get,
+ 	.set_trip_hyst	= mlxsw_thermal_module_trip_hyst_set,
+-	.get_trend	= mlxsw_thermal_trend_get,
++	.get_trend	= mlxsw_thermal_module_trend_get,
+ };
+ 
+ static int mlxsw_thermal_get_max_state(struct thermal_cooling_device *cdev,
+-- 
+2.11.0

--- a/patch/series
+++ b/patch/series
@@ -102,6 +102,7 @@ linux-4.13-thermal-intel_pch_thermal-Fix-enable-check-on.patch
 0064-Add-config-for-sensor-xdpe122-and-modify-mlx_wdt-.patch
 0065-mlxsw-qsfp_sysfs-Remove-obsolete-code-for-QSFP-EEPRO.patch
 0066-platform-mellanox-mlxreg-hotplug-Add-environmental-d.patch
+0067-mlxsw-core-thermal-Separate-temperature-trend-read-c.patch
 linux-4.16-firmware-dmi-handle-missing-DMI-data-gracefully.patch
 mellanox-backport-introduce-psample-a-new-genetlink-channel.patch
 mellanox-backport-introduce-tc-sample-action.patch


### PR DESCRIPTION
Why I did this?

Thermal algorithm not work on SN4700

How I fix?

Create a patch for linux kernel to treat temperature trend for ASIC, modules and gearboxed separately.

How I verify?

Manual test on SN4700.
