### PR TITLE
do not build DOCS and cloud-amd64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 
 	# generate linux build file for amd64_none_amd64
 	fakeroot make -f debian/rules.gen DEB_HOST_ARCH=armhf setup_armhf_none_armmp
-	fakeroot make -f debian/rules.gen DEB_HOST_ARCH=arm64 setup_arm64_none
+	fakeroot make -f debian/rules.gen DEB_HOST_ARCH=arm64 setup_arm64_none_arm64
 	fakeroot make -f debian/rules.gen DEB_HOST_ARCH=amd64 setup_amd64_none_amd64
 
 	# Applying patches and configuration changes
@@ -93,11 +93,11 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	stg import -s ../patch/series
 
 	# Building a custom kernel from Debian kernel source
-	ARCH=$(CONFIGURED_ARCH) DEB_HOST_ARCH=$(CONFIGURED_ARCH) DO_DOCS=False fakeroot make -f debian/rules -j $(shell nproc) binary-indep
+	ARCH=$(CONFIGURED_ARCH) DEB_HOST_ARCH=$(CONFIGURED_ARCH) DEB_BUILD_PROFILES=nodoc fakeroot make -f debian/rules -j $(shell nproc) binary-indep
 ifeq ($(CONFIGURED_ARCH), armhf)
 	ARCH=$(CONFIGURED_ARCH) DEB_HOST_ARCH=$(CONFIGURED_ARCH) fakeroot make -f debian/rules.gen -j $(shell nproc) binary-arch_$(CONFIGURED_ARCH)_none_armmp
 else
-	ARCH=$(CONFIGURED_ARCH) DEB_HOST_ARCH=$(CONFIGURED_ARCH) fakeroot make -f debian/rules.gen -j $(shell nproc) binary-arch_$(CONFIGURED_ARCH)_none
+	ARCH=$(CONFIGURED_ARCH) DEB_HOST_ARCH=$(CONFIGURED_ARCH) fakeroot make -f debian/rules.gen -j $(shell nproc) binary-arch_$(CONFIGURED_ARCH)_none_$(CONFIGURED_ARCH)
 endif
 	popd
 


### PR DESCRIPTION
speed up kernel compile.
1. DO_DOCS=False do not skip generate document package on 4.19, use DEB_BUILD_PROFILES=nodoc instead.
2. use arch_amd64_none_amd64 to build the amd64 kernel package, avoid generating cloud-amd64 package.
    As a result, jenkins pipeline linux-kernel-buster-build-pr job `#31` takes 1h 6min, compare to `#30` takes 1h 24min.
https://sonic-jenkins.westus2.cloudapp.azure.com/view/all/job/common/job/linux-kernel-buster-build-pr/