### PR TITLE
[Mellanox] Update existing patches and add new patches for 201911

### DIFF
--- a/patch/0053-firmware-dmi-Add-access-to-the-SKU-ID-string-backpor.patch
+++ b/patch/0053-firmware-dmi-Add-access-to-the-SKU-ID-string-backpor.patch
@@ -42,10 +42,10 @@ read
 
 Signed-off-by: Vadim Pasternak <vadimp@mellanox.com>
 ---
- drivers/firmware/dmi-id.c       | 1 +
+ drivers/firmware/dmi-id.c       | 2 ++
  drivers/firmware/dmi_scan.c     | 1 +
  include/linux/mod_devicetable.h | 1 +
- 3 files changed, 3 insertions(+)
+ 3 files changed, 4 insertions(+)
 
 diff --git a/drivers/firmware/dmi-id.c b/drivers/firmware/dmi-id.c
 index dc269cb288c2..5c864ebe1127 100644
@@ -59,6 +59,14 @@ index dc269cb288c2..5c864ebe1127 100644
  DEFINE_DMI_ATTR_WITH_SHOW(product_family,	0400, DMI_PRODUCT_FAMILY);
  DEFINE_DMI_ATTR_WITH_SHOW(board_vendor,		0444, DMI_BOARD_VENDOR);
  DEFINE_DMI_ATTR_WITH_SHOW(board_name,		0444, DMI_BOARD_NAME);
+@@ -192,6 +193,7 @@ static void __init dmi_id_init_attr_table(void)
+ 	ADD_DMI_ATTR(product_version,   DMI_PRODUCT_VERSION);
+ 	ADD_DMI_ATTR(product_serial,    DMI_PRODUCT_SERIAL);
+ 	ADD_DMI_ATTR(product_uuid,      DMI_PRODUCT_UUID);
++	ADD_DMI_ATTR(product_sku,       DMI_PRODUCT_SKU);
+ 	ADD_DMI_ATTR(product_family,      DMI_PRODUCT_FAMILY);
+ 	ADD_DMI_ATTR(board_vendor,      DMI_BOARD_VENDOR);
+ 	ADD_DMI_ATTR(board_name,        DMI_BOARD_NAME);
 diff --git a/drivers/firmware/dmi_scan.c b/drivers/firmware/dmi_scan.c
 index 150b923ef86d..d2a85a2e5b08 100644
 --- a/drivers/firmware/dmi_scan.c

--- a/patch/0063-platform-mellanox-mlxreg-io-Add-support-for-compl.patch
+++ b/patch/0063-platform-mellanox-mlxreg-io-Add-support-for-compl.patch
@@ -1,7 +1,7 @@
-From e74853715ed50660960ee7891e1979c685ab2fde Mon Sep 17 00:00:00 2001
+From 32d24501f00b494b011d34be7c751a168940dff3 Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@mellanox.com>
-Date: Fri, 13 Mar 2020 00:15:54 +0200
-Subject: [platform-next v1 2/2] platform/mellanox: mlxreg-io: Add support for
+Date: Wed, 1 Apr 2020 01:55:55 +0300
+Subject: [platform-next v1] platform/mellanox: mlxreg-io: Add support for
  complex attributes
 
 Add support for attributes composed from few registers.
@@ -13,40 +13,110 @@ or FPGA versioning, power consuming info, etcetera.
 
 Signed-off-by: Vadim Pasternak <vadimp@mellanox.com>
 ---
- drivers/platform/mellanox/mlxreg-io.c | 79 ++++++++++++++++++++++++++++++-----
- drivers/platform/x86/mlx-platform.c   | 72 +++++++++++++++++++++++++++++++
- 2 files changed, 141 insertions(+), 10 deletions(-)
+ drivers/platform/mellanox/mlxreg-hotplug.c |  36 ++++----
+ drivers/platform/mellanox/mlxreg-io.c      |  54 +++++++++---
+ drivers/platform/x86/mlx-platform.c        | 128 +++++++++++++++++++++++++++++
+ include/linux/platform_data/mlxreg.h       |   2 +
+ 4 files changed, 190 insertions(+), 30 deletions(-)
 
+diff --git a/drivers/platform/mellanox/mlxreg-hotplug.c b/drivers/platform/mellanox/mlxreg-hotplug.c
+index 9039f68b0665..832fcf282d45 100644
+--- a/drivers/platform/mellanox/mlxreg-hotplug.c
++++ b/drivers/platform/mellanox/mlxreg-hotplug.c
+@@ -204,9 +204,26 @@ static int mlxreg_hotplug_attr_init(struct mlxreg_hotplug_priv_data *priv)
+ 
+ 	/* Go over all kinds of items - psu, pwr, fan. */
+ 	for (i = 0; i < pdata->counter; i++, item++) {
++		if (item->capability) {
++			/*
++			 * Read group capability register to get actual number
++			 * of interrupt capable components and set group mask
++			 * accordingly.
++			 */
++			ret = regmap_read(priv->regmap, item->capability,
++					  &regval);
++			if (ret)
++				return ret;
++
++			item->mask = GENMASK((regval & item->mask) - 1, 0);
++		}
++
+ 		data = item->data;
+ 		/* Go over all units within the item. */
+ 		for (j = 0, k = 0; j < item->count; j++, data++) {
++			/* Skip if bit in mask is not set. */
++			if (!(item->mask & BIT(j)))
++				continue;
+ 			if (data->capability) {
+ 				/*
+ 				 * Read capability register and skip non
+@@ -519,20 +536,6 @@ static int mlxreg_hotplug_set_irq(struct mlxreg_hotplug_priv_data *priv)
+ 	item = pdata->items;
+ 
+ 	for (i = 0; i < pdata->counter; i++, item++) {
+-		if (item->capability) {
+-			/*
+-			 * Read group capability register to get actual number
+-			 * of interrupt capable components and set group mask
+-			 * accordingly.
+-			 */
+-			ret = regmap_read(priv->regmap, item->capability,
+-					  &regval);
+-			if (ret)
+-				goto out;
+-
+-			item->mask = GENMASK((regval & item->mask) - 1, 0);
+-		}
+-
+ 		/* Clear group presense event. */
+ 		ret = regmap_write(priv->regmap, item->reg +
+ 				   MLXREG_HOTPLUG_EVENT_OFF, 0);
+@@ -671,11 +674,8 @@ static int mlxreg_hotplug_probe(struct platform_device *pdev)
+ 		priv->irq = pdata->irq;
+ 	} else {
+ 		priv->irq = platform_get_irq(pdev, 0);
+-		if (priv->irq < 0) {
+-			dev_err(&pdev->dev, "Failed to get platform irq: %d\n",
+-				priv->irq);
++		if (priv->irq < 0)
+ 			return priv->irq;
+-		}
+ 	}
+ 
+ 	priv->regmap = pdata->regmap;
 diff --git a/drivers/platform/mellanox/mlxreg-io.c b/drivers/platform/mellanox/mlxreg-io.c
-index acfaf64ffde6..b8b8300928dd 100644
+index acfaf64ffde6..cc7b78301964 100644
 --- a/drivers/platform/mellanox/mlxreg-io.c
 +++ b/drivers/platform/mellanox/mlxreg-io.c
-@@ -19,6 +19,13 @@
- /* Attribute parameters. */
- #define MLXREG_IO_ATT_SIZE	10
- #define MLXREG_IO_ATT_NUM	48
-+#define MLXREG_IO_REGVAL_ARR	4
-+#define MLXREG_IO_REG_8BIT	GENMASK(7, 0)
-+#define MLXREG_IO_REG_16BIT	GENMASK(15, 0)
-+#define MLXREG_IO_REG_24BIT	GENMASK(23, 0)
-+#define MLXREG_IO_REG_32BIT	GENMASK(31, 0)
-+#define MLXREG_IO_REG_BYTE	8
-+#define MLXREG_IO_REG_WORD	16
+@@ -30,6 +30,8 @@
+  * @mlxreg_io_dev_attr: sysfs sensor device attribute array;
+  * @group: sysfs attribute group;
+  * @groups: list of sysfs attribute group for hwmon registration;
++ * @regsize: size of a register value;
++ * @regmax: max register value;
+  */
+ struct mlxreg_io_priv_data {
+ 	struct platform_device *pdev;
+@@ -39,27 +41,31 @@ struct mlxreg_io_priv_data {
+ 	struct sensor_device_attribute mlxreg_io_dev_attr[MLXREG_IO_ATT_NUM];
+ 	struct attribute_group group;
+ 	const struct attribute_group *groups[2];
++	int regsize;
++	int regmax;
+ };
  
- /**
-  * struct mlxreg_io_priv_data - driver's private data:
-@@ -45,21 +52,23 @@ static int
+ static int
  mlxreg_io_get_reg(void *regmap, struct mlxreg_core_data *data, u32 in_val,
- 		  bool rw_flag, u32 *regval)
+-		  bool rw_flag, u32 *regval)
++		  bool rw_flag, int regsize, int regmax, u32 *regval)
  {
 -	int ret;
-+	u32 val;
-+	int regnum, len, mask, i, ret;
++	int i, val, ret;
  
  	ret = regmap_read(regmap, data->reg, regval);
  	if (ret)
  		goto access_error;
--
+ 
  	/*
 -	 * There are three kinds of attributes: single bit, full register's
 -	 * bits and bit sequence. For the first kind field mask indicates which
@@ -69,7 +139,7 @@ index acfaf64ffde6..b8b8300928dd 100644
  	 */
  	if (!data->bit) {
  		/* Single bit. */
-@@ -83,6 +92,56 @@ mlxreg_io_get_reg(void *regmap, struct mlxreg_core_data *data, u32 in_val,
+@@ -83,6 +89,22 @@ mlxreg_io_get_reg(void *regmap, struct mlxreg_core_data *data, u32 in_val,
  			/* Clear relevant bits and set them to new value. */
  			*regval = (*regval & ~data->mask) | in_val;
  		}
@@ -79,55 +149,54 @@ index acfaf64ffde6..b8b8300928dd 100644
 +		 * bit size is 8 or 16. Maximum register for such case is
 +		 * respectively 0xff or 0xffff. Not relevant for the case, when
 +		 * regmap bit size is 32 and maximum registers 0xffffffff.
++		 * Compose attribute from 'regnum' registers.
 +		 */
-+		mask = regmap_get_max_register(regmap);
-+		if (mask < 0)
-+			goto access_error;
-+
-+		/*
-+		 * Get register bit length and the number of registers from
-+		 * wich this attribute is composed. Attribute can be located
-+		 * in 1, 2, 3 or 4 registers.
-+		 */
-+		switch (mask) {
-+		case MLXREG_IO_REG_8BIT:
-+			if (data->bit > MLXREG_IO_REG_24BIT)
-+				regnum = 4;
-+			else if (data->bit > MLXREG_IO_REG_16BIT)
-+				regnum = 3;
-+			else if (data->bit > MLXREG_IO_REG_8BIT)
-+				regnum = 2;
-+			else
-+				return ret;
-+			len = MLXREG_IO_REG_BYTE;
-+			break;
-+		case MLXREG_IO_REG_16BIT:
-+			if (data->bit > MLXREG_IO_REG_16BIT)
-+				regnum = 2;
-+			else
-+				return ret;
-+			len = MLXREG_IO_REG_WORD;
-+			break;
-+		case MLXREG_IO_REG_32BIT:
-+			return ret;
-+		default:
-+			return -EINVAL;
-+		}
-+
-+		/* Compose attribute from 'regnum' registers. */
-+		for (i = 1; i < regnum; i++) {
++		for (i = 1; i < data->regnum; i++) {
 +			ret = regmap_read(regmap, data->reg + i, &val);
 +			if (ret)
 +				goto access_error;
 +
-+			*regval |= rol32(val, len * i);
++			*regval |= rol32(val, regsize * i);
 +		}
-+		*regval = le32_to_cpu(*regval & mask);
++		*regval = le32_to_cpu(*regval & regmax);
  	}
  
  access_error:
+@@ -99,7 +121,8 @@ mlxreg_io_attr_show(struct device *dev, struct device_attribute *attr,
+ 	u32 regval = 0;
+ 	int ret;
+ 
+-	ret = mlxreg_io_get_reg(priv->pdata->regmap, data, 0, true, &regval);
++	ret = mlxreg_io_get_reg(priv->pdata->regmap, data, 0, true,
++				priv->regsize, priv->regmax, &regval);
+ 	if (ret)
+ 		goto access_error;
+ 
+@@ -128,7 +151,7 @@ mlxreg_io_attr_store(struct device *dev, struct device_attribute *attr,
+ 		return ret;
+ 
+ 	ret = mlxreg_io_get_reg(priv->pdata->regmap, data, input_val, false,
+-				&regval);
++				priv->regsize, priv->regmax, &regval);
+ 	if (ret)
+ 		goto access_error;
+ 
+@@ -207,6 +230,13 @@ static int mlxreg_io_probe(struct platform_device *pdev)
+ 	}
+ 
+ 	priv->pdev = pdev;
++	priv->regsize = regmap_get_val_bytes(priv->pdata->regmap);
++	if (priv->regsize < 0)
++		return priv->regsize;
++
++	priv->regmax = regmap_get_max_register(priv->pdata->regmap);
++	if (priv->regmax < 0)
++		return priv->regmax;
+ 
+ 	err = mlxreg_io_attr_init(priv);
+ 	if (err) {
 diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
-index c27548fd386a..a916a1d7ce2d 100644
+index c27548fd386a..034736cec9a6 100644
 --- a/drivers/platform/x86/mlx-platform.c
 +++ b/drivers/platform/x86/mlx-platform.c
 @@ -26,6 +26,10 @@
@@ -152,7 +221,7 @@ index c27548fd386a..a916a1d7ce2d 100644
  #define MLXPLAT_CPLD_LPC_REG_UFM_VERSION_OFFSET	0xe2
  #define MLXPLAT_CPLD_LPC_REG_PWM1_OFFSET	0xe3
  #define MLXPLAT_CPLD_LPC_REG_TACHO1_OFFSET	0xe4
-@@ -1528,6 +1536,54 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
+@@ -1304,6 +1312,32 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_regs_io_data[] = {
  		.mode = 0444,
  	},
  	{
@@ -160,24 +229,94 @@ index c27548fd386a..a916a1d7ce2d 100644
 +		.reg = MLXPLAT_CPLD_LPC_REG_CPLD1_PN_OFFSET,
 +		.bit = GENMASK(15, 0),
 +		.mode = 0444,
++		.regnum = 2,
 +	},
 +	{
 +		.label = "cpld2_pn",
 +		.reg = MLXPLAT_CPLD_LPC_REG_CPLD2_PN_OFFSET,
 +		.bit = GENMASK(15, 0),
 +		.mode = 0444,
++		.regnum = 2,
++	},
++	{
++		.label = "cpld1_version_min",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD1_MVER_OFFSET,
++		.bit = GENMASK(7, 0),
++		.mode = 0444,
++	},
++	{
++		.label = "cpld2_version_min",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD2_MVER_OFFSET,
++		.bit = GENMASK(7, 0),
++		.mode = 0444,
++	},
++	{
+ 		.label = "reset_long_pb",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET,
+ 		.mask = GENMASK(7, 0) & ~BIT(0),
+@@ -1410,6 +1444,32 @@ static struct mlxreg_core_data mlxplat_mlxcpld_msn21xx_regs_io_data[] = {
+ 		.mode = 0444,
+ 	},
+ 	{
++		.label = "cpld1_pn",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD1_PN_OFFSET,
++		.bit = GENMASK(15, 0),
++		.mode = 0444,
++		.regnum = 2,
++	},
++	{
++		.label = "cpld2_pn",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD2_PN_OFFSET,
++		.bit = GENMASK(15, 0),
++		.mode = 0444,
++		.regnum = 2,
++	},
++	{
++		.label = "cpld1_version_min",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD1_MVER_OFFSET,
++		.bit = GENMASK(7, 0),
++		.mode = 0444,
++	},
++	{
++		.label = "cpld2_version_min",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD2_MVER_OFFSET,
++		.bit = GENMASK(7, 0),
++		.mode = 0444,
++	},
++	{
+ 		.label = "reset_long_pb",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET,
+ 		.mask = GENMASK(7, 0) & ~BIT(0),
+@@ -1528,6 +1588,58 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
+ 		.mode = 0444,
+ 	},
+ 	{
++		.label = "cpld1_pn",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD1_PN_OFFSET,
++		.bit = GENMASK(15, 0),
++		.mode = 0444,
++		.regnum = 2,
++	},
++	{
++		.label = "cpld2_pn",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD2_PN_OFFSET,
++		.bit = GENMASK(15, 0),
++		.mode = 0444,
++		.regnum = 2,
 +	},
 +	{
 +		.label = "cpld3_pn",
 +		.reg = MLXPLAT_CPLD_LPC_REG_CPLD3_PN_OFFSET,
 +		.bit = GENMASK(15, 0),
 +		.mode = 0444,
++		.regnum = 2,
 +	},
 +	{
 +		.label = "cpld4_pn",
 +		.reg = MLXPLAT_CPLD_LPC_REG_CPLD4_PN_OFFSET,
 +		.bit = GENMASK(15, 0),
 +		.mode = 0444,
++		.regnum = 2,
 +	},
 +	{
 +		.label = "cpld1_version_min",
@@ -207,7 +346,7 @@ index c27548fd386a..a916a1d7ce2d 100644
  		.label = "reset_long_pb",
  		.reg = MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET,
  		.mask = GENMASK(7, 0) & ~BIT(0),
-@@ -2006,6 +2062,10 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -2006,6 +2118,10 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_CPLD2_VER_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD3_VER_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD4_VER_OFFSET:
@@ -218,7 +357,7 @@ index c27548fd386a..a916a1d7ce2d 100644
  	case MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_RST_CAUSE1_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_RST_CAUSE2_OFFSET:
-@@ -2051,6 +2111,10 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -2051,6 +2167,10 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_WD3_TMR_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_WD3_TLEFT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_WD3_ACT_OFFSET:
@@ -229,7 +368,7 @@ index c27548fd386a..a916a1d7ce2d 100644
  	case MLXPLAT_CPLD_LPC_REG_PWM1_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_TACHO1_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_TACHO2_OFFSET:
-@@ -2085,6 +2149,10 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -2085,6 +2205,10 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_CPLD2_VER_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD3_VER_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD4_VER_OFFSET:
@@ -240,7 +379,7 @@ index c27548fd386a..a916a1d7ce2d 100644
  	case MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_RST_CAUSE1_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_RST_CAUSE2_OFFSET:
-@@ -2122,6 +2190,10 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -2122,6 +2246,10 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_WD2_TLEFT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_WD3_TMR_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_WD3_TLEFT_OFFSET:
@@ -251,6 +390,26 @@ index c27548fd386a..a916a1d7ce2d 100644
  	case MLXPLAT_CPLD_LPC_REG_PWM1_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_TACHO1_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_TACHO2_OFFSET:
+diff --git a/include/linux/platform_data/mlxreg.h b/include/linux/platform_data/mlxreg.h
+index b8da8aef2446..a2adc3ad45f2 100644
+--- a/include/linux/platform_data/mlxreg.h
++++ b/include/linux/platform_data/mlxreg.h
+@@ -80,6 +80,7 @@ struct mlxreg_hotplug_device {
+  * @hpdev - hotplug device data;
+  * @health_cntr: dynamic device health indication counter;
+  * @attached: true if device has been attached after good health indication;
++ * @regnum: number of registers occupied by multi-register attribute;
+  */
+ struct mlxreg_core_data {
+ 	char label[MLXREG_CORE_LABEL_MAX_SIZE];
+@@ -92,6 +93,7 @@ struct mlxreg_core_data {
+ 	struct mlxreg_hotplug_device hpdev;
+ 	u8 health_cntr;
+ 	bool attached;
++	u8 regnum;
+ };
+ 
+ /**
 -- 
 2.11.0
 

--- a/patch/0067-Add-support-for-new-transceivers-types-QSFP-DD-and-Q.patch
+++ b/patch/0067-Add-support-for-new-transceivers-types-QSFP-DD-and-Q.patch
@@ -1,0 +1,243 @@
+From 52bf9a15d6bc3669c8102eaf9e49bdd8dbef73a0 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@mellanox.com>
+Date: Sun, 26 Apr 2020 11:54:13 +0300
+Subject: [backport] Add support for new transceivers types: QSFP-DD and QSFP+
+ with Common Management Interface Specification (CMIS).
+
+The Quad Small Form Factor Pluggable Double Density (QSFP-DD) hardware
+specification defines a form factor that supports up to 400 Gbps in
+aggregate over an 8x50-Gbps electrical interface.
+The Common Management Interface Specification (CMIS) supports multiple
+interface settings and speed negotiation controls.
+The QSFP-DD supports both optical and copper interfaces.
+
+Signed-off-by: Vadim Pasternak <vadimp@mellanox.com>
+---
+ drivers/net/ethernet/mellanox/mlxsw/core_env.c | 71 +++++++++++++++++++-------
+ drivers/net/ethernet/mellanox/mlxsw/reg.h      | 14 +++--
+ 2 files changed, 61 insertions(+), 24 deletions(-)
+
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/core_env.c b/drivers/net/ethernet/mellanox/mlxsw/core_env.c
+index 0a5495f9f4c7..066c35e42dc8 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/core_env.c
++++ b/drivers/net/ethernet/mellanox/mlxsw/core_env.c
+@@ -10,8 +10,14 @@
+ #include "item.h"
+ #include "reg.h"
+ 
++#define MLXSW_REG_MCIA_EEPROM_FLAT_MEMORY	BIT(7)
++#define MLXSW_ENV_CMIS_PAGE_OFF	0x0d
++#define MLXSW_ENV_PAGE_MAP(page) (((page) < \
++	MLXSW_REG_MCIA_TH_PAGE_NUM) ? (page) : (page) + \
++	MLXSW_ENV_CMIS_PAGE_OFF)
++
+ static int mlxsw_env_validate_cable_ident(struct mlxsw_core *core, int id,
+-					  bool *qsfp)
++					  bool *qsfp, bool *cmis)
+ {
+ 	char eeprom_tmp[MLXSW_REG_MCIA_EEPROM_SIZE];
+ 	char mcia_pl[MLXSW_REG_MCIA_LEN];
+@@ -25,15 +31,21 @@ static int mlxsw_env_validate_cable_ident(struct mlxsw_core *core, int id,
+ 		return err;
+ 	mlxsw_reg_mcia_eeprom_memcpy_from(mcia_pl, eeprom_tmp);
+ 	ident = eeprom_tmp[0];
++	*cmis = false;
+ 	switch (ident) {
+-	case MLXSW_REG_MCIA_EEPROM_MODULE_INFO_ID_SFP:
++	case MLXSW_REG_MCIA_EEPROM_MODULE_INFO_ID_SFP: /* fall-through */
++	case MLXSW_REG_MCIA_EEPROM_MODULE_INFO_ID_SFP_DD:
+ 		*qsfp = false;
+ 		break;
+ 	case MLXSW_REG_MCIA_EEPROM_MODULE_INFO_ID_QSFP: /* fall-through */
+ 	case MLXSW_REG_MCIA_EEPROM_MODULE_INFO_ID_QSFP_PLUS: /* fall-through */
+-	case MLXSW_REG_MCIA_EEPROM_MODULE_INFO_ID_QSFP28: /* fall-through */
+-	case MLXSW_REG_MCIA_EEPROM_MODULE_INFO_ID_QSFP_DD:
++	case MLXSW_REG_MCIA_EEPROM_MODULE_INFO_ID_QSFP28:
++		*qsfp = true;
++		break;
++	case MLXSW_REG_MCIA_EEPROM_MODULE_INFO_ID_QSFP_DD: /* fall-through */
++	case MLXSW_REG_MCIA_EEPROM_MODULE_INFO_ID_QSFP_PLUS_CMIS:
+ 		*qsfp = true;
++		*cmis = true;
+ 		break;
+ 	default:
+ 		return -EINVAL;
+@@ -44,8 +56,8 @@ static int mlxsw_env_validate_cable_ident(struct mlxsw_core *core, int id,
+ 
+ static int
+ mlxsw_env_query_module_eeprom(struct mlxsw_core *mlxsw_core, int module,
+-			      u16 offset, u16 size, bool qsfp, void *data,
+-			      unsigned int *p_read_size)
++			      u16 offset, u16 size, bool qsfp, bool cmis,
++			      void *data, unsigned int *p_read_size)
+ {
+ 	char eeprom_tmp[MLXSW_REG_MCIA_EEPROM_SIZE];
+ 	char mcia_pl[MLXSW_REG_MCIA_LEN];
+@@ -75,6 +87,8 @@ mlxsw_env_query_module_eeprom(struct mlxsw_core *mlxsw_core, int module,
+ 		}
+ 	}
+ 
++	if (cmis)
++		page = MLXSW_ENV_PAGE_MAP(page);
+ 	mlxsw_reg_mcia_pack(mcia_pl, module, 0, page, offset, size, i2c_addr);
+ 
+ 	err = mlxsw_reg_query(mlxsw_core, MLXSW_REG(mcia), mcia_pl);
+@@ -103,7 +117,8 @@ int mlxsw_env_module_temp_thresholds_get(struct mlxsw_core *core, int module,
+ 	char mcia_pl[MLXSW_REG_MCIA_LEN] = {0};
+ 	char mtmp_pl[MLXSW_REG_MTMP_LEN];
+ 	unsigned int module_temp;
+-	bool qsfp;
++	bool qsfp, cmis;
++	int page;
+ 	int err;
+ 
+ 	mlxsw_reg_mtmp_pack(mtmp_pl, MLXSW_REG_MTMP_MODULE_INDEX_MIN + module,
+@@ -127,21 +142,25 @@ int mlxsw_env_module_temp_thresholds_get(struct mlxsw_core *core, int module,
+ 	 */
+ 
+ 	/* Validate module identifier value. */
+-	err = mlxsw_env_validate_cable_ident(core, module, &qsfp);
++	err = mlxsw_env_validate_cable_ident(core, module, &qsfp, &cmis);
+ 	if (err)
+ 		return err;
+ 
+-	if (qsfp)
+-		mlxsw_reg_mcia_pack(mcia_pl, module, 0,
+-				    MLXSW_REG_MCIA_TH_PAGE_NUM,
++	if (qsfp) {
++		if (cmis)
++			page = MLXSW_REG_MCIA_TH_PAGE_CMIS_NUM;
++		else
++			page = MLXSW_REG_MCIA_TH_PAGE_NUM;
++		mlxsw_reg_mcia_pack(mcia_pl, module, 0, page,
+ 				    MLXSW_REG_MCIA_TH_PAGE_OFF + off,
+ 				    MLXSW_REG_MCIA_TH_ITEM_SIZE,
+ 				    MLXSW_REG_MCIA_I2C_ADDR_LOW);
+-	else
++	} else {
+ 		mlxsw_reg_mcia_pack(mcia_pl, module, 0,
+ 				    MLXSW_REG_MCIA_PAGE0_LO,
+ 				    off, MLXSW_REG_MCIA_TH_ITEM_SIZE,
+ 				    MLXSW_REG_MCIA_I2C_ADDR_HIGH);
++	}
+ 
+ 	err = mlxsw_reg_query(core, MLXSW_REG(mcia), mcia_pl);
+ 	if (err)
+@@ -165,7 +184,8 @@ int mlxsw_env_get_module_info(struct mlxsw_core *mlxsw_core, int module,
+ 	int err;
+ 
+ 	err = mlxsw_env_query_module_eeprom(mlxsw_core, module, 0, offset,
+-					    unused, module_info, &read_size);
++					    unused, unused, module_info,
++					    &read_size);
+ 	if (err)
+ 		return err;
+ 
+@@ -174,7 +194,6 @@ int mlxsw_env_get_module_info(struct mlxsw_core *mlxsw_core, int module,
+ 
+ 	module_rev_id = module_info[MLXSW_REG_MCIA_EEPROM_MODULE_INFO_REV_ID];
+ 	module_id = module_info[MLXSW_REG_MCIA_EEPROM_MODULE_INFO_ID];
+-
+ 	switch (module_id) {
+ 	case MLXSW_REG_MCIA_EEPROM_MODULE_INFO_ID_QSFP:
+ 		modinfo->type       = ETH_MODULE_SFF_8436;
+@@ -192,11 +211,13 @@ int mlxsw_env_get_module_info(struct mlxsw_core *mlxsw_core, int module,
+ 			modinfo->eeprom_len = ETH_MODULE_SFF_8436_MAX_LEN;
+ 		}
+ 		break;
+-	case MLXSW_REG_MCIA_EEPROM_MODULE_INFO_ID_SFP:
++	case MLXSW_REG_MCIA_EEPROM_MODULE_INFO_ID_SFP: /* fall-through */
++	case MLXSW_REG_MCIA_EEPROM_MODULE_INFO_ID_SFP_DD:
+ 		/* Verify if transceiver provides diagnostic monitoring page */
+ 		err = mlxsw_env_query_module_eeprom(mlxsw_core, module,
+ 						    SFP_DIAGMON, 1, unused,
+-						    &diag_mon, &read_size);
++						    unused, &diag_mon,
++						    &read_size);
+ 		if (err)
+ 			return err;
+ 
+@@ -209,6 +230,18 @@ int mlxsw_env_get_module_info(struct mlxsw_core *mlxsw_core, int module,
+ 		else
+ 			modinfo->eeprom_len = ETH_MODULE_SFF_8472_LEN / 2;
+ 		break;
++	case MLXSW_REG_MCIA_EEPROM_MODULE_INFO_ID_QSFP_DD: /* fall-through */
++	case MLXSW_REG_MCIA_EEPROM_MODULE_INFO_ID_QSFP_PLUS_CMIS:
++		modinfo->type       = ETH_MODULE_SFF_8636;
++		/* Verify if module's EEPROM is a flat memory. In case of flat
++		 * memory only page 00h 0-255 bytes can be read.
++		 */
++		if (module_info[MLXSW_REG_MCIA_EEPROM_MODULE_INFO_TYPE_ID] &
++		    MLXSW_REG_MCIA_EEPROM_FLAT_MEMORY)
++			modinfo->eeprom_len = ETH_MODULE_SFF_8636_LEN;
++		else
++			modinfo->eeprom_len = ETH_MODULE_SFF_8636_MAX_LEN;
++		break;
+ 	default:
+ 		return -EINVAL;
+ 	}
+@@ -223,7 +256,7 @@ int mlxsw_env_get_module_eeprom(struct net_device *netdev,
+ {
+ 	int offset = ee->offset;
+ 	unsigned int read_size;
+-	bool qsfp;
++	bool qsfp, cmis;
+ 	int i = 0;
+ 	int err;
+ 
+@@ -233,13 +266,13 @@ int mlxsw_env_get_module_eeprom(struct net_device *netdev,
+ 	memset(data, 0, ee->len);
+ 
+ 	/* Validate module identifier type. */
+-	err = mlxsw_env_validate_cable_ident(mlxsw_core, module, &qsfp);
++	err = mlxsw_env_validate_cable_ident(mlxsw_core, module, &qsfp, &cmis);
+ 	if (err)
+ 		return err;
+ 
+ 	while (i < ee->len) {
+ 		err = mlxsw_env_query_module_eeprom(mlxsw_core, module, offset,
+-						    ee->len - i, qsfp,
++						    ee->len - i, qsfp, cmis,
+ 						    data + i, &read_size);
+ 		if (err) {
+ 			netdev_err(netdev, "Eeprom query failed\n");
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/reg.h b/drivers/net/ethernet/mellanox/mlxsw/reg.h
+index 43e73701a125..223052256923 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/reg.h
++++ b/drivers/net/ethernet/mellanox/mlxsw/reg.h
+@@ -7830,6 +7830,7 @@ MLXSW_ITEM32(reg, mcia, size, 0x08, 0, 16);
+ #define MLXSW_REG_MCIA_PAGE0_LO_OFF		0xa0
+ #define MLXSW_REG_MCIA_TH_ITEM_SIZE		2
+ #define MLXSW_REG_MCIA_TH_PAGE_NUM		3
++#define MLXSW_REG_MCIA_TH_PAGE_CMIS_NUM		2
+ #define MLXSW_REG_MCIA_PAGE0_LO			0
+ #define MLXSW_REG_MCIA_TH_PAGE_OFF		0x80
+ 
+@@ -7840,16 +7841,19 @@ enum mlxsw_reg_mcia_eeprom_module_info_rev_id {
+ };
+ 
+ enum mlxsw_reg_mcia_eeprom_module_info_id {
+-	MLXSW_REG_MCIA_EEPROM_MODULE_INFO_ID_SFP	= 0x03,
+-	MLXSW_REG_MCIA_EEPROM_MODULE_INFO_ID_QSFP	= 0x0C,
+-	MLXSW_REG_MCIA_EEPROM_MODULE_INFO_ID_QSFP_PLUS	= 0x0D,
+-	MLXSW_REG_MCIA_EEPROM_MODULE_INFO_ID_QSFP28	= 0x11,
+-	MLXSW_REG_MCIA_EEPROM_MODULE_INFO_ID_QSFP_DD	= 0x18,
++	MLXSW_REG_MCIA_EEPROM_MODULE_INFO_ID_SFP		= 0x03,
++	MLXSW_REG_MCIA_EEPROM_MODULE_INFO_ID_QSFP		= 0x0C,
++	MLXSW_REG_MCIA_EEPROM_MODULE_INFO_ID_QSFP_PLUS		= 0x0D,
++	MLXSW_REG_MCIA_EEPROM_MODULE_INFO_ID_QSFP28		= 0x11,
++	MLXSW_REG_MCIA_EEPROM_MODULE_INFO_ID_QSFP_DD		= 0x18,
++	MLXSW_REG_MCIA_EEPROM_MODULE_INFO_ID_SFP_DD		= 0x1A,
++	MLXSW_REG_MCIA_EEPROM_MODULE_INFO_ID_QSFP_PLUS_CMIS	= 0x1E,
+ };
+ 
+ enum mlxsw_reg_mcia_eeprom_module_info {
+ 	MLXSW_REG_MCIA_EEPROM_MODULE_INFO_ID,
+ 	MLXSW_REG_MCIA_EEPROM_MODULE_INFO_REV_ID,
++	MLXSW_REG_MCIA_EEPROM_MODULE_INFO_TYPE_ID,
+ 	MLXSW_REG_MCIA_EEPROM_MODULE_INFO_SIZE,
+ };
+ 
+-- 
+2.11.0
+

--- a/patch/0068-mlxsw-core-thermal-Separate-temperature-trend-read-c.patch
+++ b/patch/0068-mlxsw-core-thermal-Separate-temperature-trend-read-c.patch
@@ -1,6 +1,6 @@
-From bc61d729cb35aba4667b3278d4297d338bf19ffe Mon Sep 17 00:00:00 2001
-From: junchao <junchao@contoso.com>
-Date: Thu, 21 May 2020 00:45:04 +0000
+From ad7ae6c9ca584c72a1f871268ac39817c46532d2 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@mellanox.com>
+Date: Thu, 21 May 2020 01:22:16 +0300
 Subject: [backport 4.9] mlxsw: core: thermal: Separate temperature trend read
  callback
 
@@ -15,19 +15,34 @@ a parent.
 Keep using the existing get_trend() callback for modules and gearboxes,
 add new get_trend() callback for chip.
 
+Signed-off-by: Vadim Pasternak <vadimp@mellanox.com>
 ---
- drivers/net/ethernet/mellanox/mlxsw/core_thermal.c | 19 +++++++++++++++++--
- 1 file changed, 17 insertions(+), 2 deletions(-)
+ drivers/net/ethernet/mellanox/mlxsw/core_thermal.c | 23 ++++++++++++++++++----
+ 1 file changed, 19 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c b/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
-index 53198e2..f944b0f 100644
+index 53198e260633..7e4f5007f021 100644
 --- a/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
 +++ b/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
-@@ -402,6 +402,21 @@ static int mlxsw_thermal_set_trip_hyst(struct thermal_zone_device *tzdev,
+@@ -402,8 +402,7 @@ static int mlxsw_thermal_set_trip_hyst(struct thermal_zone_device *tzdev,
  static int mlxsw_thermal_trend_get(struct thermal_zone_device *tzdev,
  				   int trip, enum thermal_trend *trend)
  {
+-	struct mlxsw_thermal_module *tz = tzdev->devdata;
+-	struct mlxsw_thermal *thermal = tz->parent;
 +	struct mlxsw_thermal *thermal = tzdev->devdata;
+ 
+ 	if (trip < 0 || trip >= MLXSW_THERMAL_NUM_TRIPS)
+ 		return -EINVAL;
+@@ -614,6 +613,22 @@ mlxsw_thermal_module_trip_hyst_set(struct thermal_zone_device *tzdev, int trip,
+ 	return 0;
+ }
+ 
++static int mlxsw_thermal_module_trend_get(struct thermal_zone_device *tzdev,
++					  int trip, enum thermal_trend *trend)
++{
++	struct mlxsw_thermal_module *tz = tzdev->devdata;
++	struct mlxsw_thermal *thermal = tz->parent;
 +
 +	if (trip < 0 || trip >= MLXSW_THERMAL_NUM_TRIPS)
 +		return -EINVAL;
@@ -39,12 +54,9 @@ index 53198e2..f944b0f 100644
 +	return 0;
 +}
 +
-+static int mlxsw_thermal_module_trend_get(struct thermal_zone_device *tzdev,
-+					  int trip, enum thermal_trend *trend)
-+{
- 	struct mlxsw_thermal_module *tz = tzdev->devdata;
- 	struct mlxsw_thermal *thermal = tz->parent;
- 
+ static struct thermal_zone_device_ops mlxsw_thermal_module_ops = {
+ 	.bind		= mlxsw_thermal_module_bind,
+ 	.unbind		= mlxsw_thermal_module_unbind,
 @@ -625,7 +640,7 @@ static struct thermal_zone_device_ops mlxsw_thermal_module_ops = {
  	.set_trip_temp	= mlxsw_thermal_module_trip_temp_set,
  	.get_trip_hyst	= mlxsw_thermal_module_trip_hyst_get,
@@ -65,3 +77,4 @@ index 53198e2..f944b0f 100644
  static int mlxsw_thermal_get_max_state(struct thermal_cooling_device *cdev,
 -- 
 2.11.0
+

--- a/patch/0069-watchdog-mlx-wdt-support-new-watchdog-type-with-long.patch
+++ b/patch/0069-watchdog-mlx-wdt-support-new-watchdog-type-with-long.patch
@@ -1,0 +1,368 @@
+From 341c75fdd73a915b5f052828cf04962decdaf470 Mon Sep 17 00:00:00 2001
+From: Michael Shych <michaelsh@mellanox.com>
+Date: Sun, 24 May 2020 15:28:14 +0300
+Subject: [new watchdog type 1/1] watchdog: mlx-wdt: support new watchdog type
+ with longer timeout period platform_data/mlxreg: support new watchdog type
+ with longer timeout period platform/x86: mlx-platform: support new watchdog
+ type with longer timeout
+
+New programmable logic device can have watchdog type 3 implementation.
+It's same as Type 2 with extended maximum timeout period.
+Maximum timeout is up-to 65535 sec.
+Type 3 HW watchdog implementation can exist on all Mellanox systems.
+It is differentiated by WD capability bit.
+
+Signed-off-by: Michael Shych <michaelsh@mellanox.com>
+---
+ drivers/platform/x86/mlx-platform.c  | 106 +++++++++++++++++++++++++++++++++++
+ drivers/watchdog/mlx_wdt.c           |  85 ++++++++++++++++++++++------
+ include/linux/platform_data/mlxreg.h |   5 +-
+ 3 files changed, 178 insertions(+), 18 deletions(-)
+
+diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
+index 034736cec9a6..208f4a476229 100644
+--- a/drivers/platform/x86/mlx-platform.c
++++ b/drivers/platform/x86/mlx-platform.c
+@@ -186,7 +186,9 @@
+ #define MLXPLAT_CPLD_WD_RESET_ACT_MASK	GENMASK(7, 1)
+ #define MLXPLAT_CPLD_WD_FAN_ACT_MASK	(GENMASK(7, 0) & ~BIT(4))
+ #define MLXPLAT_CPLD_WD_COUNT_ACT_MASK	(GENMASK(7, 0) & ~BIT(7))
++#define MLXPLAT_CPLD_WD_CPBLTY_MASK	(GENMASK(7, 0) & ~BIT(6))
+ #define MLXPLAT_CPLD_WD_DFLT_TIMEOUT	30
++#define MLXPLAT_CPLD_WD3_DFLT_TIMEOUT	600
+ #define MLXPLAT_CPLD_WD_MAX_DEVS	2
+ 
+ /* mlxplat_priv - platform private data
+@@ -2071,6 +2073,84 @@ static struct mlxreg_core_platform_data mlxplat_mlxcpld_wd_set_type2[] = {
+ 	},
+ };
+ 
++/* Watchdog type3: hardware implementation version 3
++ * Can be on all systems. It's differentiated by WD capability bit.
++ * Old systems (MSN2700, MSN2410, MSN2740, MSN2100 and MSN2140)
++ * still have only one main watchdog.
++ */
++static struct mlxreg_core_data mlxplat_mlxcpld_wd_main_regs_type3[] = {
++	{
++		.label = "action",
++		.reg = MLXPLAT_CPLD_LPC_REG_WD2_ACT_OFFSET,
++		.mask = MLXPLAT_CPLD_WD_RESET_ACT_MASK,
++		.bit = 0,
++	},
++	{
++		.label = "timeout",
++		.reg = MLXPLAT_CPLD_LPC_REG_WD2_TMR_OFFSET,
++		.mask = MLXPLAT_CPLD_WD_TYPE2_TO_MASK,
++		.health_cntr = MLXPLAT_CPLD_WD3_DFLT_TIMEOUT,
++	},
++	{
++		.label = "timeleft",
++		.reg = MLXPLAT_CPLD_LPC_REG_WD2_TMR_OFFSET,
++		.mask = MLXPLAT_CPLD_WD_TYPE2_TO_MASK,
++	},
++	{
++		.label = "ping",
++		.reg = MLXPLAT_CPLD_LPC_REG_WD2_ACT_OFFSET,
++		.mask = MLXPLAT_CPLD_WD_RESET_ACT_MASK,
++		.bit = 0,
++	},
++	{
++		.label = "reset",
++		.reg = MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(6),
++		.bit = 6,
++	},
++};
++
++static struct mlxreg_core_data mlxplat_mlxcpld_wd_aux_regs_type3[] = {
++	{
++		.label = "action",
++		.reg = MLXPLAT_CPLD_LPC_REG_WD3_ACT_OFFSET,
++		.mask = MLXPLAT_CPLD_WD_FAN_ACT_MASK,
++		.bit = 4,
++	},
++	{
++		.label = "timeout",
++		.reg = MLXPLAT_CPLD_LPC_REG_WD3_TMR_OFFSET,
++		.mask = MLXPLAT_CPLD_WD_TYPE2_TO_MASK,
++		.health_cntr = MLXPLAT_CPLD_WD3_DFLT_TIMEOUT,
++	},
++	{
++		.label = "timeleft",
++		.reg = MLXPLAT_CPLD_LPC_REG_WD3_TMR_OFFSET,
++		.mask = MLXPLAT_CPLD_WD_TYPE2_TO_MASK,
++	},
++	{
++		.label = "ping",
++		.reg = MLXPLAT_CPLD_LPC_REG_WD3_ACT_OFFSET,
++		.mask = MLXPLAT_CPLD_WD_FAN_ACT_MASK,
++		.bit = 4,
++	},
++};
++
++static struct mlxreg_core_platform_data mlxplat_mlxcpld_wd_set_type3[] = {
++	{
++		.data = mlxplat_mlxcpld_wd_main_regs_type3,
++		.counter = ARRAY_SIZE(mlxplat_mlxcpld_wd_main_regs_type3),
++		.version = MLX_WDT_TYPE3,
++		.identity = "mlx-wdt-main",
++	},
++	{
++		.data = mlxplat_mlxcpld_wd_aux_regs_type3,
++		.counter = ARRAY_SIZE(mlxplat_mlxcpld_wd_aux_regs_type3),
++		.version = MLX_WDT_TYPE3,
++		.identity = "mlx-wdt-aux",
++	},
++};
++
+ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
+ {
+ 	switch (reg) {
+@@ -2101,8 +2181,10 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_WD1_TMR_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_WD1_ACT_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_WD2_TMR_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_WD2_TLEFT_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_WD2_ACT_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_WD3_TMR_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_WD3_TLEFT_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_WD3_ACT_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_PWM1_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_PWM_CONTROL_OFFSET:
+@@ -2729,6 +2811,27 @@ static int mlxplat_mlxcpld_verify_bus_topology(int *nr)
+ 	return 0;
+ }
+ 
++static int mlxplat_mlxcpld_check_wd_capability(void *regmap)
++{
++	u32 regval;
++	int i, rc;
++
++	rc = regmap_read(regmap, MLXPLAT_CPLD_LPC_REG_PSU_I2C_CAP_OFFSET,
++			 &regval);
++	if (rc)
++		return rc;
++
++	if (!(regval & ~MLXPLAT_CPLD_WD_CPBLTY_MASK)) {
++		for (i = 0; i < ARRAY_SIZE(mlxplat_mlxcpld_wd_set_type3); i++) {
++			if (mlxplat_wd_data[i])
++				mlxplat_wd_data[i] =
++					&mlxplat_mlxcpld_wd_set_type3[i];
++		}
++	}
++
++	return 0;
++}
++
+ static int __init mlxplat_init(void)
+ {
+ 	struct mlxplat_priv *priv;
+@@ -2861,6 +2964,9 @@ static int __init mlxplat_init(void)
+ 	}
+ 
+ 	/* Add WD drivers. */
++	err = mlxplat_mlxcpld_check_wd_capability(priv->regmap);
++	if (err)
++		goto fail_platform_wd_register;
+ 	for (j = 0; j < MLXPLAT_CPLD_WD_MAX_DEVS; j++) {
+ 		if (mlxplat_wd_data[j]) {
+ 			mlxplat_wd_data[j]->regmap = priv->regmap;
+diff --git a/drivers/watchdog/mlx_wdt.c b/drivers/watchdog/mlx_wdt.c
+index 74b0622a1d7e..0457dc056e31 100644
+--- a/drivers/watchdog/mlx_wdt.c
++++ b/drivers/watchdog/mlx_wdt.c
+@@ -21,6 +21,7 @@
+ #define MLXREG_WDT_CLOCK_SCALE		1000
+ #define MLXREG_WDT_MAX_TIMEOUT_TYPE1	32
+ #define MLXREG_WDT_MAX_TIMEOUT_TYPE2	255
++#define MLXREG_WDT_MAX_TIMEOUT_TYPE3	65535
+ #define MLXREG_WDT_MIN_TIMEOUT		1
+ #define MLXREG_WDT_OPTIONS_BASE (WDIOF_KEEPALIVEPING | WDIOF_MAGICCLOSE | \
+ 				 WDIOF_SETTIMEOUT)
+@@ -49,6 +50,7 @@ struct mlxreg_wdt {
+ 	int tleft_idx;
+ 	int ping_idx;
+ 	int reset_idx;
++	int regmap_val_sz;
+ 	enum mlxreg_wdt_type wdt_type;
+ };
+ 
+@@ -111,7 +113,8 @@ static int mlxreg_wdt_set_timeout(struct watchdog_device *wdd,
+ 	u32 regval, set_time, hw_timeout;
+ 	int rc;
+ 
+-	if (wdt->wdt_type == MLX_WDT_TYPE1) {
++	switch (wdt->wdt_type) {
++	case MLX_WDT_TYPE1:
+ 		rc = regmap_read(wdt->regmap, reg_data->reg, &regval);
+ 		if (rc)
+ 			return rc;
+@@ -120,14 +123,32 @@ static int mlxreg_wdt_set_timeout(struct watchdog_device *wdd,
+ 		regval = (regval & reg_data->mask) | hw_timeout;
+ 		/* Rowndown to actual closest number of sec. */
+ 		set_time = BIT(hw_timeout) / MLXREG_WDT_CLOCK_SCALE;
+-	} else {
++		rc = regmap_write(wdt->regmap, reg_data->reg, regval);
++		break;
++	case MLX_WDT_TYPE2:
++		set_time = timeout;
++		rc = regmap_write(wdt->regmap, reg_data->reg, timeout);
++		break;
++	case MLX_WDT_TYPE3:
++		/* WD_TYPE3 has 2B set time register */
+ 		set_time = timeout;
+-		regval = timeout;
++		if (wdt->regmap_val_sz == 1) {
++			regval = timeout & 0xff;
++			rc = regmap_write(wdt->regmap, reg_data->reg, regval);
++			if (!rc) {
++				regval = (timeout & 0xff00) >> 8;
++				rc = regmap_write(wdt->regmap,
++						reg_data->reg + 1, regval);
++			}
++		} else {
++			rc = regmap_write(wdt->regmap, reg_data->reg, timeout);
++		}
++		break;
++	default:
++		return -EINVAL;
+ 	}
+ 
+ 	wdd->timeout = set_time;
+-	rc = regmap_write(wdt->regmap, reg_data->reg, regval);
+-
+ 	if (!rc) {
+ 		/*
+ 		 * Restart watchdog with new timeout period
+@@ -147,10 +168,25 @@ static unsigned int mlxreg_wdt_get_timeleft(struct watchdog_device *wdd)
+ {
+ 	struct mlxreg_wdt *wdt = watchdog_get_drvdata(wdd);
+ 	struct mlxreg_core_data *reg_data = &wdt->pdata->data[wdt->tleft_idx];
+-	u32 regval;
++	u32 regval, msb, lsb;
+ 	int rc;
+ 
++	if (wdt->wdt_type == MLX_WDT_TYPE2) {
+ 	rc = regmap_read(wdt->regmap, reg_data->reg, &regval);
++	} else {
++		/* WD_TYPE3 has 2 byte timeleft register */
++		if (wdt->regmap_val_sz == 1) {
++			rc = regmap_read(wdt->regmap, reg_data->reg, &lsb);
++			if (!rc) {
++				rc = regmap_read(wdt->regmap,
++						reg_data->reg + 1, &msb);
++				regval = (msb & 0xff) << 8 | (lsb & 0xff);
++			}
++		} else {
++			rc = regmap_read(wdt->regmap, reg_data->reg, &regval);
++		}
++	}
++
+ 	/* Return 0 timeleft in case of failure register read. */
+ 	return rc == 0 ? regval : 0;
+ }
+@@ -212,13 +248,23 @@ static void mlxreg_wdt_config(struct mlxreg_wdt *wdt,
+ 		wdt->wdd.info = &mlxreg_wdt_aux_info;
+ 
+ 	wdt->wdt_type = pdata->version;
+-	if (wdt->wdt_type == MLX_WDT_TYPE2) {
+-		wdt->wdd.ops = &mlxreg_wdt_ops_type2;
+-		wdt->wdd.max_timeout = MLXREG_WDT_MAX_TIMEOUT_TYPE2;
+-	} else {
++	switch (wdt->wdt_type) {
++	case MLX_WDT_TYPE1:
+ 		wdt->wdd.ops = &mlxreg_wdt_ops_type1;
+ 		wdt->wdd.max_timeout = MLXREG_WDT_MAX_TIMEOUT_TYPE1;
++		break;
++	case MLX_WDT_TYPE2:
++		wdt->wdd.ops = &mlxreg_wdt_ops_type2;
++		wdt->wdd.max_timeout = MLXREG_WDT_MAX_TIMEOUT_TYPE2;
++		break;
++	case MLX_WDT_TYPE3:
++		wdt->wdd.ops = &mlxreg_wdt_ops_type2;
++		wdt->wdd.max_timeout = MLXREG_WDT_MAX_TIMEOUT_TYPE3;
++		break;
++	default:
++		break;
+ 	}
++
+ 	wdt->wdd.min_timeout = MLXREG_WDT_MIN_TIMEOUT;
+ }
+ 
+@@ -233,21 +279,27 @@ static int mlxreg_wdt_init_timeout(struct mlxreg_wdt *wdt,
+ 
+ static int mlxreg_wdt_probe(struct platform_device *pdev)
+ {
++	struct device *dev = &pdev->dev;
+ 	struct mlxreg_core_platform_data *pdata;
+ 	struct mlxreg_wdt *wdt;
+ 	int rc;
+ 
+-	pdata = dev_get_platdata(&pdev->dev);
++	pdata = dev_get_platdata(dev);
+ 	if (!pdata) {
+-		dev_err(&pdev->dev, "Failed to get platform data.\n");
++		dev_err(dev, "Failed to get platform data.\n");
+ 		return -EINVAL;
+ 	}
+-	wdt = devm_kzalloc(&pdev->dev, sizeof(*wdt), GFP_KERNEL);
++	wdt = devm_kzalloc(dev, sizeof(*wdt), GFP_KERNEL);
+ 	if (!wdt)
+ 		return -ENOMEM;
+ 
+-	wdt->wdd.parent = &pdev->dev;
++	wdt->wdd.parent = dev;
+ 	wdt->regmap = pdata->regmap;
++	rc = regmap_get_val_bytes(wdt->regmap);
++	if (rc < 0)
++		return -EINVAL;
++
++	wdt->regmap_val_sz = rc;
+ 	mlxreg_wdt_config(wdt, pdata);
+ 
+ 	if ((pdata->features & MLXREG_CORE_WD_FEATURE_NOWAYOUT))
+@@ -265,12 +317,11 @@ static int mlxreg_wdt_probe(struct platform_device *pdev)
+ 		set_bit(WDOG_HW_RUNNING, &wdt->wdd.status);
+ 	}
+ 	mlxreg_wdt_check_card_reset(wdt);
+-	rc = devm_watchdog_register_device(&pdev->dev, &wdt->wdd);
++	rc = devm_watchdog_register_device(dev, &wdt->wdd);
+ 
+ register_error:
+ 	if (rc)
+-		dev_err(&pdev->dev,
+-			"Cannot register watchdog device (err=%d)\n", rc);
++		dev_err(dev, "Cannot register watchdog device (err=%d)\n", rc);
+ 	return rc;
+ }
+ 
+diff --git a/include/linux/platform_data/mlxreg.h b/include/linux/platform_data/mlxreg.h
+index a2adc3ad45f2..03d768d73a5f 100644
+--- a/include/linux/platform_data/mlxreg.h
++++ b/include/linux/platform_data/mlxreg.h
+@@ -43,10 +43,13 @@
+  *
+  * TYPE1 HW watchdog implementation exist in old systems.
+  * All new systems have TYPE2 HW watchdog.
++ * TYPE3 HW watchdog can exist on all systems with new CPLD.
++ * TYPE3 is selected by WD capability bit.
+  */
+ enum mlxreg_wdt_type {
+ 	MLX_WDT_TYPE1,
+ 	MLX_WDT_TYPE2,
++	MLX_WDT_TYPE3,
+ };
+ 
+ /**
+@@ -91,7 +94,7 @@ struct mlxreg_core_data {
+ 	umode_t	mode;
+ 	struct device_node *np;
+ 	struct mlxreg_hotplug_device hpdev;
+-	u8 health_cntr;
++	u32 health_cntr;
+ 	bool attached;
+ 	u8 regnum;
+ };
+-- 
+2.11.0
+

--- a/patch/series
+++ b/patch/series
@@ -102,7 +102,9 @@ linux-4.13-thermal-intel_pch_thermal-Fix-enable-check-on.patch
 0064-Add-config-for-sensor-xdpe122-and-modify-mlx_wdt-.patch
 0065-mlxsw-qsfp_sysfs-Remove-obsolete-code-for-QSFP-EEPRO.patch
 0066-platform-mellanox-mlxreg-hotplug-Add-environmental-d.patch
-0067-mlxsw-core-thermal-Separate-temperature-trend-read-c.patch
+0067-Add-support-for-new-transceivers-types-QSFP-DD-and-Q.patch
+0068-mlxsw-core-thermal-Separate-temperature-trend-read-c.patch
+0069-watchdog-mlx-wdt-support-new-watchdog-type-with-long.patch
 linux-4.16-firmware-dmi-handle-missing-DMI-data-gracefully.patch
 mellanox-backport-introduce-psample-a-new-genetlink-channel.patch
 mellanox-backport-introduce-tc-sample-action.patch


### PR DESCRIPTION
**1. Update existing patches:**

> - 0053-firmware-dmi-Add-access-to-the-SKU-ID-string-backpor.patch   
     add one line which was missing during the rebase.

> - 0063-platform-mellanox-mlxreg-io-Add-support-for-compl.patch  
      Add support for more registers.

> -  0067-mlxsw-core-thermal-Separate-temperature-trend-read-c.patch 
     re-numbering it to  0068-mlxsw-core-thermal-Separate-temperature-trend-read-c.patch  and update the patch(the previous patch was rebased due to not applied in the correct sequence, now we correct the sequence and just take the original patch) 

**2. Add new patches with new hw-mgmt V.7.0010.1000** 

> - 0067-Add-support-for-new-transceivers-types-QSFP-DD-and-Q.patch 
      to support QSFP-DD cable

> - 0069-watchdog-mlx-wdt-support-new-watchdog-type-with-long.patch  
       to support new type of watchdog