### PR TITLE
use kstrtol_from_user in dni_dps460 driver

### DIFF
--- a/patch/driver-hwmon-pmbus-dni_dps460-use-kstrtol-from-user.patch
+++ b/patch/driver-hwmon-pmbus-dni_dps460-use-kstrtol-from-user.patch
@@ -1,0 +1,31 @@
+use kstrtol_from_user to convert user data
+
+From: Guohan Lu <lguohan@gmail.com>
+
+
+---
+ drivers/hwmon/pmbus/dni_dps460.c |    4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/hwmon/pmbus/dni_dps460.c b/drivers/hwmon/pmbus/dni_dps460.c
+index 9d684ea5c..893864652 100644
+--- a/drivers/hwmon/pmbus/dni_dps460.c
++++ b/drivers/hwmon/pmbus/dni_dps460.c
+@@ -118,7 +118,7 @@ static ssize_t set_target(struct device *dev, struct device_attribute *devattr,
+ 	unsigned long val;
+ 	unsigned long rpm;
+
+-	err = kstrtol(buf, 10, &rpm);
++	err = kstrtol_from_user(buf, count, 10, &rpm);
+ 	if (err)
+ 		return err;
+
+@@ -150,7 +150,7 @@ static ssize_t set_pec(struct device *dev, struct device_attribute *dummy,
+ 	long val;
+ 	int err;
+
+-	err = kstrtol(buf, 10, &val);
++	err = kstrtol_from_user(buf, count, 10, &val);
+ 	if (err < 0)
+ 		return err;
+

--- a/patch/series
+++ b/patch/series
@@ -22,6 +22,7 @@ driver-hwmon-max6620-update.patch
 driver-hwmon-max6658-fix-write-convrate.patch
 driver-hwmon-pmbus-dni_dps460.patch
 driver-hwmon-pmbus-dni_dps460-update-pmbus-core.patch
+driver-hwmon-pmbus-dni_dps460-use-kstrtol-from-user.patch
 driver-hwmon-pmbus-dps1900.patch
 driver-support-tun-config-carrier-enable.patch
 driver-support-optoe.patch


### PR DESCRIPTION
To avoid following kernel crash:

[   34.668610] Call Trace:
[   34.697843]  __mutex_add_waiter+0x23/0x50
[   34.745783]  __mutex_lock.isra.8+0x1d1/0x4a0
[   34.796846]  ? __handle_mm_fault+0xa83/0x1270
[   34.848948]  ? _kstrtoull+0x3b/0x90
[   34.890657]  set_target+0x95/0xf0 [dni_dps460]
[   34.943797]  kernfs_fop_write+0x116/0x190
[   34.991740]  vfs_write+0xa5/0x1a0
[   35.031363]  ksys_write+0x57/0xd0
[   35.070990]  do_syscall_64+0x53/0x110
[   35.114773]  entry_SYSCALL_64_after_hwframe+0x44/0xa9

Signed-off-by: Guohan Lu <lguohan@gmail.com>