### PR TITLE
Issue #153 patch psample to safely unload the module

### DIFF
--- a/patch/net-psample-module-unload.patch
+++ b/patch/net-psample-module-unload.patch
@@ -1,3 +1,15 @@
+From f4f17bf3fa004085e89c94607488c57cacd1103d Mon Sep 17 00:00:00 2001
+From: PADMANABHAN NARAYANAN <PADMANABHAN_N@DELL.COM>
+Date: Tue, 21 Jul 2020 22:25:00 -0700
+Subject: [PATCH 2/2] Issue #153 patch psample to safely unload the module
+
+Remove the __ro_after_init macro to enable safe unloading in case of 4.9 kernel.
+Patch not necessary for 4.19.
+
+---
+ net/psample/psample.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
 diff --git a/net/psample/psample.c b/net/psample/psample.c
 index 1c014bc..c0438ea 100644
 --- a/net/psample/psample.c
@@ -20,3 +32,6 @@ index 1c014bc..c0438ea 100644
  	.name		= PSAMPLE_GENL_NAME,
  	.version	= PSAMPLE_GENL_VERSION,
  	.maxattr	= PSAMPLE_ATTR_MAX,
+-- 
+2.11.0
+

--- a/patch/net-psample-module-unload.patch
+++ b/patch/net-psample-module-unload.patch
@@ -1,0 +1,22 @@
+diff --git a/net/psample/psample.c b/net/psample/psample.c
+index 1c014bc..c0438ea 100644
+--- a/net/psample/psample.c
++++ b/net/psample/psample.c
+@@ -34,7 +34,7 @@ static const struct genl_multicast_group psample_nl_mcgrps[] = {
+ 	[PSAMPLE_NL_MCGRP_SAMPLE] = { .name = PSAMPLE_NL_MCGRP_SAMPLE_NAME },
+ };
+ 
+-static struct genl_family psample_nl_family __ro_after_init;
++static struct genl_family psample_nl_family;
+ 
+ static int psample_group_nl_fill(struct sk_buff *msg,
+ 				 struct psample_group *group,
+@@ -105,7 +105,7 @@ static const struct genl_ops psample_nl_ops[] = {
+ 	}
+ };
+ 
+-static struct genl_family psample_nl_family __ro_after_init = {
++static struct genl_family psample_nl_family = {
+ 	.name		= PSAMPLE_GENL_NAME,
+ 	.version	= PSAMPLE_GENL_VERSION,
+ 	.maxattr	= PSAMPLE_ATTR_MAX,

--- a/patch/series
+++ b/patch/series
@@ -117,6 +117,7 @@ net-backport-ipv6-missing-route.patch
 Support-for-fullcone-nat.patch
 driver-ixgbe-external-phy.patch
 fix_ismt_alignment_issue.patch
+net-psample-module-unload.patch
 #
 # This series applies on GIT commit 1451b36b2b0d62178e42f648d8a18131af18f7d8
 # Tkernel-sched-core-fix-cgroup-fork-race.patch


### PR DESCRIPTION
Address https://github.com/Azure/sonic-linux-kernel/issues/153 by removing the __ro_after_init macro.
Checked that with this patch, it is possible to remove the module safely.