### PR TITLE
hwmon-lm75: backport support for PCT2075 thermal sensor

### DIFF
--- a/patch/0001-hwmon-lm75-add-support-for-PCT2075.patch
+++ b/patch/0001-hwmon-lm75-add-support-for-PCT2075.patch
@@ -1,0 +1,115 @@
+From 90b3a0b833131831bf259e3506aaf9f29317aae9 Mon Sep 17 00:00:00 2001
+From: Daniel Mack <daniel@zonque.org>
+Date: Thu, 11 Jul 2019 14:45:04 +0200
+Subject: [PATCH 1/6] hwmon: (lm75) add support for PCT2075
+
+The NXP PCT2075 is largely compatible with other chips already supported
+by the LM75 driver. It uses an 11-bit resolution and defaults to 100 ms
+sampling period. The datasheet is here:
+
+  https://www.nxp.com/docs/en/data-sheet/PCT2075.pdf
+
+Signed-off-by: Daniel Mack <daniel@zonque.org>
+Link: https://lore.kernel.org/r/20190711124504.7580-2-daniel@zonque.org
+[groeck: Documentation update]
+Signed-off-by: Guenter Roeck <linux@roeck-us.net>
+---
+ Documentation/hwmon/lm75 | 35 +++++++++++++++++++++++++----------
+ drivers/hwmon/lm75.c     | 10 ++++++++++
+ 2 files changed, 35 insertions(+), 10 deletions(-)
+
+diff --git a/Documentation/hwmon/lm75 b/Documentation/hwmon/lm75
+index ac95edfcd907..ef7c2afa604e 100644
+--- a/Documentation/hwmon/lm75
++++ b/Documentation/hwmon/lm75
+@@ -46,20 +46,35 @@ Supported chips:
+     Prefixes: 'tmp100', 'tmp101', 'tmp105', 'tmp112', 'tmp175', 'tmp75', 'tmp75c', 'tmp275'
+     Addresses scanned: none
+     Datasheet: Publicly available at the Texas Instruments website
+-               http://www.ti.com/product/tmp100
+-               http://www.ti.com/product/tmp101
+-               http://www.ti.com/product/tmp105
+-               http://www.ti.com/product/tmp112
+-               http://www.ti.com/product/tmp75
+-               http://www.ti.com/product/tmp75c
+-               http://www.ti.com/product/tmp175
+-               http://www.ti.com/product/tmp275
+-  * NXP LM75B
+-    Prefix: 'lm75b'
++
++	       http://www.ti.com/product/tmp100
++
++	       http://www.ti.com/product/tmp101
++
++	       http://www.ti.com/product/tmp105
++
++	       http://www.ti.com/product/tmp112
++
++	       http://www.ti.com/product/tmp75
++
++	       http://www.ti.com/product/tmp75b
++
++	       http://www.ti.com/product/tmp75c
++
++	       http://www.ti.com/product/tmp175
++
++	       http://www.ti.com/product/tmp275
++
++  * NXP LM75B, PCT2075
++
++    Prefix: 'lm75b', 'pct2075'
++
+     Addresses scanned: none
+     Datasheet: Publicly available at the NXP website
+                http://www.nxp.com/documents/data_sheet/LM75B.pdf
+ 
++               http://www.nxp.com/docs/en/data-sheet/PCT2075.pdf
++
+ Author: Frodo Looijaard <frodol@dds.nl>
+ 
+ Description
+diff --git a/drivers/hwmon/lm75.c b/drivers/hwmon/lm75.c
+index 7f28912c9abc..9a04af3d7449 100644
+--- a/drivers/hwmon/lm75.c
++++ b/drivers/hwmon/lm75.c
+@@ -48,6 +48,7 @@ enum lm75_type {		/* keep sorted in alphabetical order */
+ 	max6625,
+ 	max6626,
+ 	mcp980x,
++	pct2075,
+ 	stds75,
+ 	tcn75,
+ 	tmp100,
+@@ -343,6 +344,10 @@ lm75_probe(struct i2c_client *client, const struct i2c_device_id *id)
+ 		data->resolution = 9;
+ 		data->sample_time = MSEC_PER_SEC / 8;
+ 		break;
++	case pct2075:
++		data->resolution = 11;
++		data->sample_time = MSEC_PER_SEC / 10;
++		break;
+ 	case mcp980x:
+ 		data->resolution_limits = 9;
+ 		/* fall through */
+@@ -416,6 +421,7 @@ static const struct i2c_device_id lm75_ids[] = {
+ 	{ "max6625", max6625, },
+ 	{ "max6626", max6626, },
+ 	{ "mcp980x", mcp980x, },
++	{ "pct2075", pct2075, },
+ 	{ "stds75", stds75, },
+ 	{ "tcn75", tcn75, },
+ 	{ "tmp100", tmp100, },
+@@ -475,6 +481,10 @@ static const struct of_device_id lm75_of_match[] = {
+ 		.compatible = "maxim,mcp980x",
+ 		.data = (void *)mcp980x
+ 	},
++	{
++		.compatible = "nxp,pct2075",
++		.data = (void *)pct2075
++	},
+ 	{
+ 		.compatible = "st,stds75",
+ 		.data = (void *)stds75
+-- 
+2.17.1
+

--- a/patch/0004-dt-bindings-hwmon-Add-missing-documentation-for-lm75.patch
+++ b/patch/0004-dt-bindings-hwmon-Add-missing-documentation-for-lm75.patch
@@ -1,0 +1,61 @@
+From c3eab8b7b730548ade06b71fad6b1d12fd53f28a Mon Sep 17 00:00:00 2001
+From: Jagan Teki <jagan@amarulasolutions.com>
+Date: Tue, 12 Feb 2019 17:08:08 +0530
+Subject: [PATCH 4/6] dt-bindings: hwmon: Add missing documentation for lm75
+
+Add missing dt-binding documentation for lm75 hwmon sensor.
+
+Signed-off-by: Jagan Teki <jagan@amarulasolutions.com>
+Acked-by: Rob Herring <robh@kernel.org>
+Signed-off-by: Guenter Roeck <linux@roeck-us.net>
+---
+ .../devicetree/bindings/hwmon/lm75.txt        | 37 +++++++++++++++++++
+ 1 file changed, 37 insertions(+)
+ create mode 100644 Documentation/devicetree/bindings/hwmon/lm75.txt
+
+diff --git a/Documentation/devicetree/bindings/hwmon/lm75.txt b/Documentation/devicetree/bindings/hwmon/lm75.txt
+new file mode 100644
+index 000000000000..12d8cf7cf592
+--- /dev/null
++++ b/Documentation/devicetree/bindings/hwmon/lm75.txt
+@@ -0,0 +1,37 @@
++*LM75 hwmon sensor.
++
++Required properties:
++- compatible: manufacturer and chip name, one of
++		"adi,adt75",
++		"dallas,ds1775",
++		"dallas,ds75",
++		"dallas,ds7505",
++		"gmt,g751",
++		"national,lm75",
++		"national,lm75a",
++		"national,lm75b",
++		"maxim,max6625",
++		"maxim,max6626",
++		"maxim,max31725",
++		"maxim,max31726",
++		"maxim,mcp980x",
++		"st,stds75",
++		"st,stlm75",
++		"microchip,tcn75",
++		"ti,tmp100",
++		"ti,tmp101",
++		"ti,tmp105",
++		"ti,tmp112",
++		"ti,tmp175",
++		"ti,tmp275",
++		"ti,tmp75",
++		"ti,tmp75c",
++
++- reg: I2C bus address of the device
++
++Example:
++
++sensor@48 {
++	compatible = "st,stlm75";
++	reg = <0x48>;
++};
+-- 
+2.17.1
+

--- a/patch/0005-dt-bindings-hwmon-Add-tmp75b-to-lm75.txt.patch
+++ b/patch/0005-dt-bindings-hwmon-Add-tmp75b-to-lm75.txt.patch
@@ -1,0 +1,29 @@
+From de27b34d7fc91ed109c78ed89442f42427ac0c5c Mon Sep 17 00:00:00 2001
+From: Iker Perez del Palomar Sustatxa <iker.perez@codethink.co.uk>
+Date: Fri, 3 May 2019 17:15:01 +0100
+Subject: [PATCH 5/6] dt-bindings: hwmon: Add tmp75b to lm75.txt
+
+Update the LM75's devicetree definition to allow Texas Instruments
+TMP75B be probed.
+
+Signed-off-by: Iker Perez del Palomar Sustatxa <iker.perez@codethink.co.uk>
+Signed-off-by: Guenter Roeck <linux@roeck-us.net>
+---
+ Documentation/devicetree/bindings/hwmon/lm75.txt | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/Documentation/devicetree/bindings/hwmon/lm75.txt b/Documentation/devicetree/bindings/hwmon/lm75.txt
+index 12d8cf7cf592..586b5ed70be7 100644
+--- a/Documentation/devicetree/bindings/hwmon/lm75.txt
++++ b/Documentation/devicetree/bindings/hwmon/lm75.txt
+@@ -25,6 +25,7 @@ Required properties:
+ 		"ti,tmp175",
+ 		"ti,tmp275",
+ 		"ti,tmp75",
++		"ti,tmp75b",
+ 		"ti,tmp75c",
+ 
+ - reg: I2C bus address of the device
+-- 
+2.17.1
+

--- a/patch/0006-device-tree-bindinds-add-NXP-PCT2075-as-compatible-d.patch
+++ b/patch/0006-device-tree-bindinds-add-NXP-PCT2075-as-compatible-d.patch
@@ -1,0 +1,31 @@
+From 248bae1d862533e1e1b6a1a0ba32f8b73bbfe57e Mon Sep 17 00:00:00 2001
+From: Daniel Mack <daniel@zonque.org>
+Date: Thu, 11 Jul 2019 14:45:03 +0200
+Subject: [PATCH 6/6] device-tree: bindinds: add NXP PCT2075 as compatible
+ device to LM75
+
+The PCT2075 is compatible to other chips that are already handled by
+the LM75 driver.
+
+Signed-off-by: Daniel Mack <daniel@zonque.org>
+Link: https://lore.kernel.org/r/20190711124504.7580-1-daniel@zonque.org
+Signed-off-by: Guenter Roeck <linux@roeck-us.net>
+---
+ Documentation/devicetree/bindings/hwmon/lm75.txt | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/Documentation/devicetree/bindings/hwmon/lm75.txt b/Documentation/devicetree/bindings/hwmon/lm75.txt
+index 586b5ed70be7..273616702c51 100644
+--- a/Documentation/devicetree/bindings/hwmon/lm75.txt
++++ b/Documentation/devicetree/bindings/hwmon/lm75.txt
+@@ -15,6 +15,7 @@ Required properties:
+ 		"maxim,max31725",
+ 		"maxim,max31726",
+ 		"maxim,mcp980x",
++		"nxp,pct2075",
+ 		"st,stds75",
+ 		"st,stlm75",
+ 		"microchip,tcn75",
+-- 
+2.17.1
+

--- a/patch/series
+++ b/patch/series
@@ -1,5 +1,5 @@
 # This series applies on GIT commit 18c5597832fcf6988111b05a9a1607ae148723c
-# (marvel)
+# (Marvell)
 # 0001-armhf-default-config-for-the-sonic-patches.patch
 # 0001-arm64-default-config-for-sonic-patches.patch
 
@@ -32,7 +32,12 @@ driver-support-optoe-chunk-offset-fix.patch
 driver-support-optoe-QSFP_DD.patch
 driver-net-tg3-add-param-short-preamble-and-reset.patch
 e1000-Do-not-perform-reset-in-reset_task-if-we-are-a.patch
-# (Marvel)
+0001-hwmon-lm75-add-support-for-PCT2075.patch
+0004-dt-bindings-hwmon-Add-missing-documentation-for-lm75.patch
+0005-dt-bindings-hwmon-Add-tmp75b-to-lm75.txt.patch
+0006-device-tree-bindinds-add-NXP-PCT2075-as-compatible-d.patch
+#
+# (Marvell)
 # 0042-Marvell-a385-Micron-4G-flash-support.patch
 # 0042-armhf-additional-configs.patch
 # 0042-armhf-proc-dma-kconfig.patch


### PR DESCRIPTION
New platform HW may use the NXP-PCT2075 thermal sensor which is compatible with
the lm75 sensor. These patches backport support for that sensor from 5.x
kernels.