### PR TITLE
Improve netfilter fullclone nat support patch

### DIFF
--- a/patch/Support-for-fullcone-nat.patch
+++ b/patch/Support-for-fullcone-nat.patch
@@ -30,6 +30,8 @@ the ASIC and the Kernel* in the NAT HLD [1].
 [1]: https://github.com/kirankella/SONiC/blob/nat_doc_changes/doc/nat/nat_design_spec.md
 
 Signed-off-by: Kiran Kella <kiran.kella@broadcom.com>
+[forward port to Linux v4.19, https://github.com/Azure/sonic-linux-kernel/pull/147]
+Signed-off-by: Akhilesh Samineni <akhilesh.samineni@broadcom.com>
 ---
  include/net/netfilter/nf_conntrack.h     |   3 +
  include/net/netfilter/nf_nat.h           |   6 +

--- a/patch/Support-for-fullcone-nat.patch
+++ b/patch/Support-for-fullcone-nat.patch
@@ -3,6 +3,33 @@ From: Kiran Kella <kiran.kella@broadcom.com>
 Date: Fri, 6 Sep 2019 20:54:19 -0700
 Subject: [PATCH] netfilter: nf_nat: Support fullcone NAT
 
+Changes done in the kernel to ensure 3-tuple uniqueness of the conntrack
+entries for the fullcone nat functionality.
+
+*   Hashlist is maintained for the 3-tuple unique keys (Protocol/Source
+    IP/Port) for all the conntrack entries.
+
+*   When NAT table rules are created with the fullcone option, the
+    SNAT/POSTROUTING stage ensures the ports from the pool are picked up in
+    such a way that the 3-tuple is uniquely assigned.
+
+*   In the DNAT/POSTROUTING stage, the fullcone behavior is ensured by checking
+    and reusing the 3-tuple for the Source IP/Port in the original direction.
+
+*   When the pool is exhausted of the 3-tuple assignments, the packets are
+    dropped, else, they will be going out of the router they being 5-tuple
+    unique (which is not intended).
+
+*   Passing fullcone option using iptables is part of another PR (in
+    sonic-buildimage repo).
+
+The kernel changes mentioned above are done to counter the challenges
+explained in the section *3.4.2.1 Handling NAT model mismatch between
+the ASIC and the Kernel* in the NAT HLD [1].
+
+[1]: https://github.com/kirankella/SONiC/blob/nat_doc_changes/doc/nat/nat_design_spec.md
+
+Signed-off-by: Kiran Kella <kiran.kella@broadcom.com>
 ---
  include/net/netfilter/nf_conntrack.h     |   3 +
  include/net/netfilter/nf_nat.h           |   6 +

--- a/patch/Support-for-fullcone-nat.patch
+++ b/patch/Support-for-fullcone-nat.patch
@@ -251,9 +251,9 @@ index 2268b10a9dcf..1b83427a7a68 100644
 +		nf_ct_invert_tuplepr(&reply, tuple);
 +		/* Compare against the destination in the reply */
 +		if (same_reply_dst(ct, &reply) &&
-+	    		net_eq(net, nf_ct_net(ct)) &&
-+	    		nf_ct_zone_equal(ct, zone, IP_CT_DIR_ORIGINAL)) {
-+				return 1;
++		    net_eq(net, nf_ct_net(ct)) &&
++		    nf_ct_zone_equal(ct, zone, IP_CT_DIR_ORIGINAL)) {
++			return 1;
 +		}
 +	}
 +	return 0;
@@ -363,7 +363,7 @@ index 2268b10a9dcf..1b83427a7a68 100644
 +			 * as a translated source for a given tuple, use that
 +			 */
 +			if (find_appropriate_dst(net, zone, l3proto, l4proto,
-+					 	orig_tuple, tuple)) {
++						orig_tuple, tuple)) {
 +				if (!nf_nat_used_tuple(tuple, ct)) {
 +					goto out;
 +				}
@@ -374,7 +374,7 @@ index 2268b10a9dcf..1b83427a7a68 100644
 +			}
 +		}
 +	}
-+ 
++
  	/* 2) Select the least-used IP/proto combination in the given range */
  	*tuple = *orig_tuple;
 -	find_best_ips_proto(zone, tuple, range, ct, maniptype);

--- a/patch/Support-for-fullcone-nat.patch
+++ b/patch/Support-for-fullcone-nat.patch
@@ -1,7 +1,7 @@
 From 67cc2bd46c7ad1431ddd1819cdfad6ecc08a7593 Mon Sep 17 00:00:00 2001
 From: Kiran Kella <kiran.kella@broadcom.com>
 Date: Fri, 6 Sep 2019 20:54:19 -0700
-Subject: [PATCH] Support for fullcone nat
+Subject: [PATCH] netfilter: nf_nat: Support fullcone NAT
 
 ---
  include/net/netfilter/nf_conntrack.h     |   3 +

--- a/patch/Support-for-fullcone-nat.patch
+++ b/patch/Support-for-fullcone-nat.patch
@@ -1,3 +1,25 @@
+From 67cc2bd46c7ad1431ddd1819cdfad6ecc08a7593 Mon Sep 17 00:00:00 2001
+From: Kiran Kella <kiran.kella@broadcom.com>
+Date: Fri, 6 Sep 2019 20:54:19 -0700
+Subject: [PATCH] Support for fullcone nat
+
+---
+ include/net/netfilter/nf_conntrack.h     |   3 +
+ include/net/netfilter/nf_nat.h           |   6 +
+ include/net/netfilter/nf_nat_l4proto.h   |  12 +-
+ include/uapi/linux/netfilter/nf_nat.h    |   1 +
+ net/ipv4/netfilter/nf_nat_proto_gre.c    |   8 +-
+ net/ipv4/netfilter/nf_nat_proto_icmp.c   |   6 +-
+ net/ipv6/netfilter/nf_nat_proto_icmpv6.c |   5 +-
+ net/netfilter/nf_nat_core.c              | 173 ++++++++++++++++++++---
+ net/netfilter/nf_nat_proto_common.c      |  32 +++--
+ net/netfilter/nf_nat_proto_dccp.c        |   6 +-
+ net/netfilter/nf_nat_proto_sctp.c        |   6 +-
+ net/netfilter/nf_nat_proto_tcp.c         |   6 +-
+ net/netfilter/nf_nat_proto_udp.c         |  12 +-
+ net/netfilter/nf_nat_proto_unknown.c     |   4 +-
+ 14 files changed, 220 insertions(+), 60 deletions(-)
+
 diff --git a/include/net/netfilter/nf_conntrack.h b/include/net/netfilter/nf_conntrack.h
 index f45141bdbb83..64b9293a31f6 100644
 --- a/include/net/netfilter/nf_conntrack.h


### PR DESCRIPTION
No functionality is changed. Only the format is changed, so it’s easier to apply to the Linux kernel source and to upstream it.