### PR TITLE
add internal patch marker

### DIFF
--- a/patch/series
+++ b/patch/series
@@ -77,7 +77,7 @@ driver-ixgbe-external-phy.patch
 0021-platform-x86-mlx-platform-Remove-PSU-EEPROM-configur.patch
 ############################################################
 #
-# Internal patches below (placeholder)
+# Internal patches will be added below (placeholder)
 # Do not add any public patch below this marker
 #
 ############################################################

--- a/patch/series
+++ b/patch/series
@@ -75,3 +75,9 @@ driver-ixgbe-external-phy.patch
 0019-mlxsw-i2c-Allow-flexible-setting-of-I2C-transactions.patch
 0020-mlxsw-core-Set-different-thermal-polling-time-based.patch
 0021-platform-x86-mlx-platform-Remove-PSU-EEPROM-configur.patch
+############################################################
+#
+# Internal patches below (placeholder)
+# Do not add any public patch below this marker
+#
+############################################################


### PR DESCRIPTION
all internal patches will be add below the marker. This eases
internal patch management when public patches change

Signed-off-by: Guohan Lu <lguohan@gmail.com>