### PR TITLE
Fix manage-config option comparison issue

### DIFF
--- a/manage-config
+++ b/manage-config
@@ -108,6 +108,7 @@ if [ -e ${exclusion_file} -o -e ${inclusion_file} ]; then
             if [ ! -z "$opt" ] && [[ ! "$opt" =~ ^#.* ]]; then
                 n=${opt%=*}
                 v="${opt#*=}"
+                v=$(sed -e 's/^"//' -e 's/"$//' <<< "$v")
                 s=$(scripts/config --file ${CONFIG_FILE} -k --state $n)
                 if [ ! "$s" = "$v" ]; then
                     ret=2


### PR DESCRIPTION
- What I did

To make **manage-config** able to compare string type kernel options.

- How I did it

Use **sed** to remove the double quote at prefix and suffix of the option value if it exists.

- How to verify it

Take `CONFIG_MODULE_SIG_KEY="debian/certs/test.pem"` in kconfig-inclusions for example.
Originally, if I give a kernel options with a double quoted string type value, it will return comparison failure.
```
Checking added kernel options...
Option CONFIG_MODULE_SIG_KEY should be set to ["debian/certs/test.pem"] instead of [debian/certs/test.pem]
```

After modification, it can pass the verification.