### PR TITLE
[max6620] Use Fan Dynamics registers for speed calculation and add attributes to retrieve fan fault status

### DIFF
--- a/patch/driver-hwmon-max6620-add-alarm-attribute.patch
+++ b/patch/driver-hwmon-max6620-add-alarm-attribute.patch
@@ -1,0 +1,66 @@
+From f84450af3a86368a64c36c114a2a69068a130d47 Mon Sep 17 00:00:00 2001
+From: Arun Saravanan Balachandran <Arun_Saravanan_Balac@dell.com>
+Date: Wed, 17 Mar 2021 18:04:29 +0530
+Subject: [PATCH] Add attributes in MAX6620 driver to retrieve fan fault status
+
+Signed-off-by: Arun Saravanan Balachandran <Arun_Saravanan_Balac@dell.com>
+---
+ drivers/hwmon/max6620.c | 18 +++++++++++++-----
+ 1 file changed, 13 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/hwmon/max6620.c b/drivers/hwmon/max6620.c
+index 5c8b155..6f921bb 100644
+--- a/drivers/hwmon/max6620.c
++++ b/drivers/hwmon/max6620.c
+@@ -283,6 +283,9 @@ static ssize_t set_target(struct device *dev, struct device_attribute *devattr,
+ 	i2c_smbus_write_byte_data(client, target_reg[attr->index], target1);
+ 	i2c_smbus_write_byte_data(client, target_reg[attr->index] + 1, target2);
+ 
++	/* Setting TACH count re-enables fan fault detection */
++	data->fault &= ~(1 << attr->index);
++
+ 	mutex_unlock(&data->update_lock);
+ 
+ 	return count;
+@@ -469,14 +472,11 @@ static ssize_t get_alarm(struct device *dev, struct device_attribute *devattr, c
+ 	struct i2c_client *client = to_i2c_client(dev);
+ 	int alarm = 0;
+ 
++	mutex_lock(&data->update_lock);
+ 	if (data->fault & (1 << attr->index)) {
+-		mutex_lock(&data->update_lock);
+ 		alarm = 1;
+-		data->fault &= ~(1 << attr->index);
+-		data->fault |= i2c_smbus_read_byte_data(client,
+-							MAX6620_REG_FAULT);
+-		mutex_unlock(&data->update_lock);
+ 	}
++	mutex_unlock(&data->update_lock);
+ 
+ 	return sprintf(buf, "%d\n", alarm);
+ }
+@@ -485,6 +485,10 @@ static SENSOR_DEVICE_ATTR(fan1_input, S_IRUGO, get_fan, NULL, 0);
+ static SENSOR_DEVICE_ATTR(fan2_input, S_IRUGO, get_fan, NULL, 1);
+ static SENSOR_DEVICE_ATTR(fan3_input, S_IRUGO, get_fan, NULL, 2);
+ static SENSOR_DEVICE_ATTR(fan4_input, S_IRUGO, get_fan, NULL, 3);
++static SENSOR_DEVICE_ATTR(fan1_alarm, S_IRUGO, get_alarm, NULL, 0);
++static SENSOR_DEVICE_ATTR(fan2_alarm, S_IRUGO, get_alarm, NULL, 1);
++static SENSOR_DEVICE_ATTR(fan3_alarm, S_IRUGO, get_alarm, NULL, 2);
++static SENSOR_DEVICE_ATTR(fan4_alarm, S_IRUGO, get_alarm, NULL, 3);
+ static SENSOR_DEVICE_ATTR(fan1_target, S_IWUSR | S_IRUGO, get_target, set_target, 0);
+ static SENSOR_DEVICE_ATTR(fan1_div, S_IWUSR | S_IRUGO, get_div, set_div, 0);
+ // static SENSOR_DEVICE_ATTR(pwm1_enable, S_IWUSR | S_IRUGO, get_enable, set_enable, 0);
+@@ -507,6 +511,10 @@ static struct attribute *max6620_attrs[] = {
+ 	&sensor_dev_attr_fan2_input.dev_attr.attr,
+ 	&sensor_dev_attr_fan3_input.dev_attr.attr,
+ 	&sensor_dev_attr_fan4_input.dev_attr.attr,
++	&sensor_dev_attr_fan1_alarm.dev_attr.attr,
++	&sensor_dev_attr_fan2_alarm.dev_attr.attr,
++	&sensor_dev_attr_fan3_alarm.dev_attr.attr,
++	&sensor_dev_attr_fan4_alarm.dev_attr.attr,
+ 	&sensor_dev_attr_fan1_target.dev_attr.attr,
+ 	&sensor_dev_attr_fan1_div.dev_attr.attr,
+ //	&sensor_dev_attr_pwm1_enable.dev_attr.attr,
+-- 
+2.7.4
+

--- a/patch/driver-hwmon-max6620-fix-rpm-calc.patch
+++ b/patch/driver-hwmon-max6620-fix-rpm-calc.patch
@@ -52,7 +52,7 @@ index 3c337c7b0..76c1f7f54 100644
  		rpm = 0;
  	} else {
 -		rpm = ((clock / (data->tach[attr->index] << 3)) * 30 * DIV_FROM_REG(data->fandyn[attr->index]));
-+		rpm = (60 * sr * clock)/(tach * np);
++		rpm = (60 * DIV_FROM_REG(data->fandyn[attr->index]) * clock)/(tach * np);
  	}
 -
  	return sprintf(buf, "%d\n", rpm);
@@ -90,7 +90,7 @@ index 3c337c7b0..76c1f7f54 100644
  		rpm = 0;
  	} else {
 -		rpm = ((60 * kscale * clock) / (ktach << 3));
-+		rpm = (60 * sr * clock)/(target * np);
++		rpm = (60 * DIV_FROM_REG(data->fandyn[attr->index]) * clock)/(target * np);
  	}
  	return sprintf(buf, "%d\n", rpm);
  }
@@ -131,7 +131,7 @@ index 3c337c7b0..76c1f7f54 100644
 -
 -	i2c_smbus_write_byte_data(client, target_reg[attr->index], data->target[attr->index]);
 -	i2c_smbus_write_byte_data(client, target_reg[attr->index]+0x01, 0x00);
-+	target = (60 * sr * 8192)/(rpm * np);
++	target = (60 * DIV_FROM_REG(data->fandyn[attr->index]) * clock)/(rpm * np);
 +	target1 = (target >> 3) & 0xff;
 +	target2 = (target << 5) & 0xe0;
 +	i2c_smbus_write_byte_data(client, target_reg[attr->index], target1);

--- a/patch/driver-hwmon-max6620-update.patch
+++ b/patch/driver-hwmon-max6620-update.patch
@@ -22,7 +22,7 @@ index 76c1f7f54..fb4919520 100644
  };
 @@ -231,6 +231,7 @@ static ssize_t get_fan(struct device *dev, struct device_attribute *devattr, cha
  	} else {
- 		rpm = (60 * sr * clock)/(tach * np);
+ 		rpm = (60 * DIV_FROM_REG(data->fandyn[attr->index]) * clock)/(tach * np);
  	}
 +
  	return sprintf(buf, "%d\n", rpm);

--- a/patch/series
+++ b/patch/series
@@ -19,6 +19,7 @@ kernel-add-kexec-reboot-string.patch
 driver-hwmon-max6620.patch
 driver-hwmon-max6620-fix-rpm-calc.patch
 driver-hwmon-max6620-update.patch
+driver-hwmon-max6620-add-alarm-attribute.patch
 driver-hwmon-max6658-fix-write-convrate.patch
 driver-hwmon-pmbus-dni_dps460.patch
 driver-hwmon-pmbus-dni_dps460-update-pmbus-core.patch


### PR DESCRIPTION
Incorporate following enhancements in MAX6620 driver:

- Use value of Fan Dynamics registers for tach count to speed (in RPM) conversion and vice versa
- Add sysfs attributes (fan*_alarm) to retrieve fan fault status

Signed-off-by: Arun Saravanan Balachandran <Arun_Saravanan_Balac@dell.com>