### PR TITLE
cisco specific kernel patches

### DIFF
--- a/patch/cisco-acpi-spi-nor.patch
+++ b/patch/cisco-acpi-spi-nor.patch
@@ -1,0 +1,30 @@
+commit baaac832b8a63756933f71ead22ce2bb9ed98eb0
+Author: balsup <balsup@contoso.com>
+Date:   Thu Aug 13 23:57:13 2020 +0000
+
+    Support ACPI table match
+
+diff --git a/drivers/mtd/devices/m25p80.c b/drivers/mtd/devices/m25p80.c
+index c4a1d04..3e77c6d 100644
+--- a/drivers/mtd/devices/m25p80.c
++++ b/drivers/mtd/devices/m25p80.c
+@@ -319,11 +319,19 @@ static const struct of_device_id m25p_of_table[] = {
+ };
+ MODULE_DEVICE_TABLE(of, m25p_of_table);
+ 
++static const struct acpi_device_id m25p_acpi_table[] = {
++	{ "JEDEC,SPI-NOR", 0 },
++	{ "ACPI0000", 0 },
++	{}
++};
++MODULE_DEVICE_TABLE(acpi, m25p_acpi_table);
++
+ static struct spi_mem_driver m25p80_driver = {
+ 	.spidrv = {
+ 		.driver = {
+ 			.name	= "m25p80",
+ 			.of_match_table = m25p_of_table,
++			.acpi_match_table = m25p_acpi_table,
+ 		},
+ 		.id_table	= m25p_ids,
+ 	},

--- a/patch/cisco-add-support-for-ltc2979-chip.patch
+++ b/patch/cisco-add-support-for-ltc2979-chip.patch
@@ -1,0 +1,67 @@
+From 841b03103bc8336f1737c48859897bfd6b63730b Mon Sep 17 00:00:00 2001
+From: Harsh Bhuwania <hbhuwani@cisco.com>
+Date: Thu, 8 Oct 2020 14:38:04 -0700
+Subject: [PATCH] Add support for LTC2979 chip
+
+---
+ drivers/hwmon/pmbus/ltc2978.c | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/hwmon/pmbus/ltc2978.c b/drivers/hwmon/pmbus/ltc2978.c
+index 94eea2a..388244d 100644
+--- a/drivers/hwmon/pmbus/ltc2978.c
++++ b/drivers/hwmon/pmbus/ltc2978.c
+@@ -27,7 +27,7 @@
+ #include <linux/regulator/driver.h>
+ #include "pmbus.h"
+ 
+-enum chips { ltc2974, ltc2975, ltc2977, ltc2978, ltc2980, ltc3880, ltc3882,
++enum chips { ltc2974, ltc2975, ltc2977, ltc2978, ltc2979, ltc2980, ltc3880, ltc3882,
+ 	ltc3883, ltc3886, ltc3887, ltm2987, ltm4675, ltm4676 };
+ 
+ /* Common for all chips */
+@@ -67,6 +67,8 @@ enum chips { ltc2974, ltc2975, ltc2977, ltc2978, ltc2980, ltc3880, ltc3882,
+ #define LTC2977_ID			0x0130
+ #define LTC2978_ID_REV1			0x0110	/* Early revision */
+ #define LTC2978_ID_REV2			0x0120
++#define LTC2979_ID_A			0x8060
++#define LTC2979_ID_B			0x8070
+ #define LTC2980_ID_A			0x8030	/* A/B for two die IDs */
+ #define LTC2980_ID_B			0x8040
+ #define LTC3880_ID			0x4020
+@@ -503,6 +505,7 @@ static int ltc2978_write_word_data(struct i2c_client *client, int page,
+ 	{"ltc2975", ltc2975},
+ 	{"ltc2977", ltc2977},
+ 	{"ltc2978", ltc2978},
++        {"ltc2979", ltc2979},
+ 	{"ltc2980", ltc2980},
+ 	{"ltc3880", ltc3880},
+ 	{"ltc3882", ltc3882},
+@@ -569,6 +572,8 @@ static int ltc2978_get_id(struct i2c_client *client)
+ 		return ltc2977;
+ 	else if (chip_id == LTC2978_ID_REV1 || chip_id == LTC2978_ID_REV2)
+ 		return ltc2978;
++	else if (chip_id == LTC2979_ID_A || chip_id == LTC2979_ID_B)
++		return ltc2979;
+ 	else if (chip_id == LTC2980_ID_A || chip_id == LTC2980_ID_B)
+ 		return ltc2980;
+ 	else if (chip_id == LTC3880_ID)
+@@ -668,6 +673,7 @@ static int ltc2978_probe(struct i2c_client *client,
+ 		break;
+ 	case ltc2977:
+ 	case ltc2978:
++        case ltc2979:
+ 	case ltc2980:
+ 	case ltm2987:
+ 		info->read_word_data = ltc2978_read_word_data;
+@@ -761,6 +767,7 @@ static int ltc2978_probe(struct i2c_client *client,
+ 	{ .compatible = "lltc,ltc2975" },
+ 	{ .compatible = "lltc,ltc2977" },
+ 	{ .compatible = "lltc,ltc2978" },
++        { .compatible = "lltc,ltc2979" },
+ 	{ .compatible = "lltc,ltc2980" },
+ 	{ .compatible = "lltc,ltc3880" },
+ 	{ .compatible = "lltc,ltc3882" },
+-- 
+1.8.3.1
+

--- a/patch/cisco-ds4424-null-of-node.patch
+++ b/patch/cisco-ds4424-null-of-node.patch
@@ -1,0 +1,23 @@
+commit 166b37e58be17655da39f3d7ad61014db4afa4a1
+Author: Billie R Alsup <balsup@cisco.com>
+Date:   Sun Aug 23 14:57:55 2020 -0700
+
+    Allow NULL of_node
+
+diff --git a/drivers/iio/dac/ds4424.c b/drivers/iio/dac/ds4424.c
+index 714a97f91..ae9be7926 100644
+--- a/drivers/iio/dac/ds4424.c
++++ b/drivers/iio/dac/ds4424.c
+@@ -236,12 +236,6 @@ static int ds4424_probe(struct i2c_client *client,
+ 	indio_dev->dev.of_node = client->dev.of_node;
+ 	indio_dev->dev.parent = &client->dev;
+ 
+-	if (!client->dev.of_node) {
+-		dev_err(&client->dev,
+-				"Not found DT.\n");
+-		return -ENODEV;
+-	}
+-
+ 	data->vcc_reg = devm_regulator_get(&client->dev, "vcc");
+ 	if (IS_ERR(data->vcc_reg)) {
+ 		dev_err(&client->dev,

--- a/patch/cisco-ltc4306-peer.patch
+++ b/patch/cisco-ltc4306-peer.patch
@@ -1,0 +1,431 @@
+commit f9575da7c4864489a373f438f3993387fd9b69c4
+Author: Billie R Alsup <balsup@cisco.com>
+Date:   Sun Aug 23 14:30:43 2020 -0700
+
+    Support multiple peer chips
+
+diff --git a/drivers/i2c/muxes/i2c-mux-ltc4306.c b/drivers/i2c/muxes/i2c-mux-ltc4306.c
+index a9af93259..0d8bf4c3b 100644
+--- a/drivers/i2c/muxes/i2c-mux-ltc4306.c
++++ b/drivers/i2c/muxes/i2c-mux-ltc4306.c
+@@ -38,26 +38,40 @@
+ enum ltc_type {
+ 	ltc_4305,
+ 	ltc_4306,
++	ltc_4306x2,
+ };
+ 
+ struct chip_desc {
+ 	u8 nchans;
+-	u8 num_gpios;
++	u8 ngpios;
++        u8 nchips;
++        u8 chip_stride;
+ };
+ 
++#define MAX_CHIPS       2
++
+ struct ltc4306 {
+-	struct regmap *regmap;
++	struct regmap *regmap[MAX_CHIPS];
+ 	struct gpio_chip gpiochip;
+ 	const struct chip_desc *chip;
++        struct i2c_client *peers[MAX_CHIPS];
+ };
+ 
+ static const struct chip_desc chips[] = {
+ 	[ltc_4305] = {
+ 		.nchans = LTC4305_MAX_NCHANS,
++                .nchips = 1,
+ 	},
+ 	[ltc_4306] = {
+ 		.nchans = LTC4306_MAX_NCHANS,
+-		.num_gpios = 2,
++		.ngpios = 2,
++                .nchips = 1,
++	},
++	[ltc_4306x2] = {
++		.nchans = LTC4306_MAX_NCHANS,
++		.ngpios = 2,
++                .nchips = 2,
++                .chip_stride = 8,
+ 	},
+ };
+ 
+@@ -79,21 +93,27 @@ static int ltc4306_gpio_get(struct gpio_chip *chip, unsigned int offset)
+ 	struct ltc4306 *data = gpiochip_get_data(chip);
+ 	unsigned int val;
+ 	int ret;
++        u8 ngpios = data->chip->ngpios;
++        u8 chip_index = offset / ngpios;
++        u8 chip_offset = offset % ngpios;
+ 
+-	ret = regmap_read(data->regmap, LTC_REG_CONFIG, &val);
++	ret = regmap_read(data->regmap[chip_index], LTC_REG_CONFIG, &val);
+ 	if (ret < 0)
+ 		return ret;
+ 
+-	return !!(val & BIT(1 - offset));
++	return !!(val & BIT(1 - chip_offset));
+ }
+ 
+ static void ltc4306_gpio_set(struct gpio_chip *chip, unsigned int offset,
+ 			     int value)
+ {
+ 	struct ltc4306 *data = gpiochip_get_data(chip);
++        u8 ngpios = data->chip->ngpios;
++        u8 chip_index = offset / ngpios;
++        u8 chip_offset = offset % ngpios;
+ 
+-	regmap_update_bits(data->regmap, LTC_REG_CONFIG, BIT(5 - offset),
+-			   value ? BIT(5 - offset) : 0);
++	regmap_update_bits(data->regmap[chip_index], LTC_REG_CONFIG, BIT(5 - chip_offset),
++			   value ? BIT(5 - chip_offset) : 0);
+ }
+ 
+ static int ltc4306_gpio_get_direction(struct gpio_chip *chip,
+@@ -102,31 +122,40 @@ static int ltc4306_gpio_get_direction(struct gpio_chip *chip,
+ 	struct ltc4306 *data = gpiochip_get_data(chip);
+ 	unsigned int val;
+ 	int ret;
++        u8 ngpios = data->chip->ngpios;
++        u8 chip_index = offset / ngpios;
++        u8 chip_offset = offset % ngpios;
+ 
+-	ret = regmap_read(data->regmap, LTC_REG_MODE, &val);
++	ret = regmap_read(data->regmap[chip_index], LTC_REG_MODE, &val);
+ 	if (ret < 0)
+ 		return ret;
+ 
+-	return !!(val & BIT(7 - offset));
++	return !!(val & BIT(7 - chip_offset));
+ }
+ 
+ static int ltc4306_gpio_direction_input(struct gpio_chip *chip,
+ 					unsigned int offset)
+ {
+ 	struct ltc4306 *data = gpiochip_get_data(chip);
++        u8 ngpios = data->chip->ngpios;
++        u8 chip_index = offset / ngpios;
++        u8 chip_offset = offset % ngpios;
+ 
+-	return regmap_update_bits(data->regmap, LTC_REG_MODE,
+-				  BIT(7 - offset), BIT(7 - offset));
++	return regmap_update_bits(data->regmap[chip_index], LTC_REG_MODE,
++				  BIT(7 - chip_offset), BIT(7 - chip_offset));
+ }
+ 
+ static int ltc4306_gpio_direction_output(struct gpio_chip *chip,
+ 					 unsigned int offset, int value)
+ {
+ 	struct ltc4306 *data = gpiochip_get_data(chip);
++        u8 ngpios = data->chip->ngpios;
++        u8 chip_index = offset / ngpios;
++        u8 chip_offset = offset % ngpios;
+ 
+ 	ltc4306_gpio_set(chip, offset, value);
+-	return regmap_update_bits(data->regmap, LTC_REG_MODE,
+-				  BIT(7 - offset), 0);
++	return regmap_update_bits(data->regmap[chip_offset], LTC_REG_MODE,
++				  BIT(7 - chip_offset), 0);
+ }
+ 
+ static int ltc4306_gpio_set_config(struct gpio_chip *chip,
+@@ -134,32 +163,37 @@ static int ltc4306_gpio_set_config(struct gpio_chip *chip,
+ {
+ 	struct ltc4306 *data = gpiochip_get_data(chip);
+ 	unsigned int val;
++        u8 ngpios = data->chip->ngpios;
++        u8 chip_index = offset / ngpios;
++        u8 chip_offset = offset % ngpios;
+ 
+ 	switch (pinconf_to_config_param(config)) {
+ 	case PIN_CONFIG_DRIVE_OPEN_DRAIN:
+ 		val = 0;
+ 		break;
+ 	case PIN_CONFIG_DRIVE_PUSH_PULL:
+-		val = BIT(4 - offset);
++		val = BIT(4 - chip_offset);
+ 		break;
+ 	default:
+ 		return -ENOTSUPP;
+ 	}
+ 
+-	return regmap_update_bits(data->regmap, LTC_REG_MODE,
+-				  BIT(4 - offset), val);
++	return regmap_update_bits(data->regmap[chip_index], LTC_REG_MODE,
++				  BIT(4 - chip_offset), val);
+ }
+ 
+ static int ltc4306_gpio_init(struct ltc4306 *data)
+ {
+-	struct device *dev = regmap_get_device(data->regmap);
++	struct device *dev = regmap_get_device(data->regmap[0]);
++        u8 chip,nchips;
+ 
+-	if (!data->chip->num_gpios)
++	if (!data->chip->ngpios)
+ 		return 0;
+ 
++        nchips = data->chip->nchips;
+ 	data->gpiochip.label = dev_name(dev);
+ 	data->gpiochip.base = -1;
+-	data->gpiochip.ngpio = data->chip->num_gpios;
++	data->gpiochip.ngpio = data->chip->ngpios * nchips;
+ 	data->gpiochip.parent = dev;
+ 	data->gpiochip.can_sleep = true;
+ 	data->gpiochip.get_direction = ltc4306_gpio_get_direction;
+@@ -171,7 +205,9 @@ static int ltc4306_gpio_init(struct ltc4306 *data)
+ 	data->gpiochip.owner = THIS_MODULE;
+ 
+ 	/* gpiolib assumes all GPIOs default input */
+-	regmap_write(data->regmap, LTC_REG_MODE, LTC_GPIO_ALL_INPUT);
++        for (chip = 0; chip < nchips; ++chip) {
++            regmap_write(data->regmap[chip], LTC_REG_MODE, LTC_GPIO_ALL_INPUT);
++        }
+ 
+ 	return devm_gpiochip_add_data(dev, &data->gpiochip, data);
+ }
+@@ -180,7 +216,7 @@ static int ltc4306_select_mux(struct i2c_mux_core *muxc, u32 chan)
+ {
+ 	struct ltc4306 *data = i2c_mux_priv(muxc);
+ 
+-	return regmap_update_bits(data->regmap, LTC_REG_SWITCH,
++	return regmap_update_bits(data->regmap[0], LTC_REG_SWITCH,
+ 				  LTC_SWITCH_MASK, BIT(7 - chan));
+ }
+ 
+@@ -188,13 +224,47 @@ static int ltc4306_deselect_mux(struct i2c_mux_core *muxc, u32 chan)
+ {
+ 	struct ltc4306 *data = i2c_mux_priv(muxc);
+ 
+-	return regmap_update_bits(data->regmap, LTC_REG_SWITCH,
++	return regmap_update_bits(data->regmap[0], LTC_REG_SWITCH,
++				  LTC_SWITCH_MASK, 0);
++}
++
++static int ltc4306_select_mux_multiple(struct i2c_mux_core *muxc, u32 chan)
++{
++	struct ltc4306 *data = i2c_mux_priv(muxc);
++        u8 nchans = data->chip->nchans;
++        u8 nchips = data->chip->nchips;
++        u8 chip_index = chan / nchans;
++        u8 chip_chan = chan % nchans;
++        u8 chip;
++        int e = 0;
++
++        for (chip = 0; !e && (chip < nchips); ++chip) {
++            if (chip != chip_index) {
++                e = regmap_update_bits(data->regmap[chip], LTC_REG_SWITCH,
++				  LTC_SWITCH_MASK, 0);
++            }
++        }
++        if (!e) {
++            e = regmap_update_bits(data->regmap[chip_index], LTC_REG_SWITCH,
++				  LTC_SWITCH_MASK, BIT(7 - chip_chan));
++        }
++        return e;
++}
++
++static int ltc4306_deselect_mux_multiple(struct i2c_mux_core *muxc, u32 chan)
++{
++	struct ltc4306 *data = i2c_mux_priv(muxc);
++        u8 nchans = data->chip->nchans;
++        u8 chip_index = chan / nchans;
++
++	return regmap_update_bits(data->regmap[chip_index], LTC_REG_SWITCH,
+ 				  LTC_SWITCH_MASK, 0);
+ }
+ 
+ static const struct i2c_device_id ltc4306_id[] = {
+ 	{ "ltc4305", ltc_4305 },
+ 	{ "ltc4306", ltc_4306 },
++	{ "ltc4306x2", ltc_4306x2 },
+ 	{ }
+ };
+ MODULE_DEVICE_TABLE(i2c, ltc4306_id);
+@@ -202,6 +272,7 @@ MODULE_DEVICE_TABLE(i2c, ltc4306_id);
+ static const struct of_device_id ltc4306_of_match[] = {
+ 	{ .compatible = "lltc,ltc4305", .data = &chips[ltc_4305] },
+ 	{ .compatible = "lltc,ltc4306", .data = &chips[ltc_4306] },
++	{ .compatible = "lltc,ltc4306x2", .data = &chips[ltc_4306x2] },
+ 	{ }
+ };
+ MODULE_DEVICE_TABLE(of, ltc4306_of_match);
+@@ -216,6 +287,11 @@ static int ltc4306_probe(struct i2c_client *client)
+ 	bool idle_disc;
+ 	unsigned int val = 0;
+ 	int num, ret;
++        struct i2c_client *peers[MAX_CHIPS] = { 0 };
++        u8 nchips, nchans;
++        u16 addr;
++
++        peers[0] = client;
+ 
+ 	chip = of_device_get_match_data(&client->dev);
+ 
+@@ -225,45 +301,57 @@ static int ltc4306_probe(struct i2c_client *client)
+ 	idle_disc = device_property_read_bool(&client->dev,
+ 					      "i2c-mux-idle-disconnect");
+ 
++
++        nchips = chip->nchips;
++        addr = client->addr;
++        for (num = 1; num < nchips; ++num) {
++            addr += chip->chip_stride;
++            peers[num] = i2c_new_dummy(client->adapter, addr);
++            if (!peers[num]) {
++                dev_err(&client->dev, "address 0x%x unavailable\n", addr);
++                ret = -EADDRINUSE;
++                goto cleanup_i2c;
++            }
++        }
+ 	muxc = i2c_mux_alloc(adap, &client->dev,
+-			     chip->nchans, sizeof(*data),
+-			     I2C_MUX_LOCKED, ltc4306_select_mux,
+-			     idle_disc ? ltc4306_deselect_mux : NULL);
+-	if (!muxc)
+-		return -ENOMEM;
++			     chip->nchans * nchips, sizeof(*data),
++			     I2C_MUX_LOCKED, 
++                             (nchips < 2) ? ltc4306_select_mux : ltc4306_select_mux_multiple,
++			     idle_disc ? ((nchips < 2) ? ltc4306_deselect_mux : ltc4306_deselect_mux_multiple) : NULL);
++	if (!muxc) {
++                ret = -ENOMEM;
++                goto cleanup_i2c;
++        }
++
+ 	data = i2c_mux_priv(muxc);
+ 	data->chip = chip;
+ 
+ 	i2c_set_clientdata(client, muxc);
+ 
+-	data->regmap = devm_regmap_init_i2c(client, &ltc4306_regmap_config);
+-	if (IS_ERR(data->regmap)) {
+-		ret = PTR_ERR(data->regmap);
+-		dev_err(&client->dev, "Failed to allocate register map: %d\n",
+-			ret);
+-		return ret;
+-	}
++        for (num = 0; num < nchips; ++num) {
++            data->peers[num] = peers[num];
++            data->regmap[num] = devm_regmap_init_i2c(peers[num], &ltc4306_regmap_config);
++            if (IS_ERR(data->regmap[num])) {
++                    ret = PTR_ERR(data->regmap[num]);
++                    dev_err(&client->dev, "Failed to allocate register map: %d\n",
++                            ret);
++                    goto cleanup_regmap;
++            }
++        }
+ 
+ 	/* Reset and enable the mux if an enable GPIO is specified. */
++        /* Presumption is that one pin enables all peers. */
+ 	gpio = devm_gpiod_get_optional(&client->dev, "enable", GPIOD_OUT_LOW);
+-	if (IS_ERR(gpio))
+-		return PTR_ERR(gpio);
++	if (IS_ERR(gpio)) {
++                ret = PTR_ERR(gpio);
++                goto cleanup_regmap;
++        }
+ 
+ 	if (gpio) {
+ 		udelay(1);
+ 		gpiod_set_value(gpio, 1);
+ 	}
+ 
+-	/*
+-	 * Write the mux register at addr to verify
+-	 * that the mux is in fact present. This also
+-	 * initializes the mux to disconnected state.
+-	 */
+-	if (regmap_write(data->regmap, LTC_REG_SWITCH, 0) < 0) {
+-		dev_warn(&client->dev, "probe failed\n");
+-		return -ENODEV;
+-	}
+-
+ 	if (device_property_read_bool(&client->dev,
+ 				      "ltc,downstream-accelerators-enable"))
+ 		val |= LTC_DOWNSTREAM_ACCL_EN;
+@@ -272,19 +360,36 @@ static int ltc4306_probe(struct i2c_client *client)
+ 				      "ltc,upstream-accelerators-enable"))
+ 		val |= LTC_UPSTREAM_ACCL_EN;
+ 
+-	if (regmap_write(data->regmap, LTC_REG_CONFIG, val) < 0)
+-		return -ENODEV;
++	/*
++	 * Write the mux register at addr to verify
++	 * that the mux is in fact present. This also
++	 * initializes the mux to disconnected state.
++	 */
++        for (num = 0; num < nchips; ++num) {
++            if (regmap_write(data->regmap[num], LTC_REG_SWITCH, 0) < 0) {
++                    dev_warn(&client->dev, "probe failed\n");
++                    ret = -ENODEV;
++                    goto cleanup_regmap;
++            }
++            if (regmap_write(data->regmap[num], LTC_REG_CONFIG, val) < 0) {
++                    ret = -ENODEV;
++                    goto cleanup_regmap;
++            }
++        }
++
+ 
+ 	ret = ltc4306_gpio_init(data);
+-	if (ret < 0)
+-		return ret;
++	if (ret < 0) {
++                goto cleanup_regmap;
++        }
+ 
+ 	/* Now create an adapter for each channel */
+-	for (num = 0; num < chip->nchans; num++) {
++        nchans = chip->nchans * nchips;
++	for (num = 0; num < nchans; num++) {
+ 		ret = i2c_mux_add_adapter(muxc, 0, num, 0);
+ 		if (ret) {
+ 			i2c_mux_del_adapters(muxc);
+-			return ret;
++			goto cleanup_regmap;
+ 		}
+ 	}
+ 
+@@ -293,14 +398,39 @@ static int ltc4306_probe(struct i2c_client *client)
+ 		 num, client->name);
+ 
+ 	return 0;
++
++cleanup_regmap:
++        for (num = 0; num < nchips; ++num) {
++            if (IS_ERR(data->regmap[num])) {
++                break;
++            }
++            regmap_exit(data->regmap[num]);
++        }
++cleanup_i2c:
++        for (num = 1; num < nchips; ++num) {
++            if (peers[num]) {
++                i2c_unregister_device(peers[num]);
++            }
++        }
++
++        return ret;
+ }
+ 
+ static int ltc4306_remove(struct i2c_client *client)
+ {
+ 	struct i2c_mux_core *muxc = i2c_get_clientdata(client);
++	struct ltc4306 *data = i2c_mux_priv(muxc);
++        u8 nchips = data->chip->nchips;
++        u8 chip;
+ 
+ 	i2c_mux_del_adapters(muxc);
+ 
++        for (chip = 1; chip < nchips; ++chip) {
++            if (data->peers[chip]) {
++                i2c_unregister_device(data->peers[chip]);
++            }
++        }
++
+ 	return 0;
+ }
+ 

--- a/patch/cisco-mdio-mux-support-acpi.patch
+++ b/patch/cisco-mdio-mux-support-acpi.patch
@@ -1,0 +1,76 @@
+commit 3ba8590f2288c21f51e7c1454ccdcb557b220dd8
+Author: balsup <balsup@contoso.com>
+Date:   Thu Aug 13 23:27:15 2020 +0000
+
+    Support ACPI tables
+
+diff --git a/drivers/net/phy/mdio-mux.c b/drivers/net/phy/mdio-mux.c
+index 0a86f1e..bd21313 100644
+--- a/drivers/net/phy/mdio-mux.c
++++ b/drivers/net/phy/mdio-mux.c
+@@ -12,6 +12,7 @@
+ #include <linux/device.h>
+ #include <linux/module.h>
+ #include <linux/phy.h>
++#include <linux/property.h>
+ 
+ #define DRV_DESCRIPTION "MDIO bus multiplexer driver"
+ 
+@@ -93,16 +94,16 @@ int mdio_mux_init(struct device *dev,
+ 		  struct mii_bus *mux_bus)
+ {
+ 	struct device_node *parent_bus_node;
+-	struct device_node *child_bus_node;
++	struct fwnode_handle *child_bus_node;
+ 	int r, ret_val;
+ 	struct mii_bus *parent_bus;
+ 	struct mdio_mux_parent_bus *pb;
+ 	struct mdio_mux_child_bus *cb;
+ 
+-	if (!mux_node)
+-		return -ENODEV;
+-
+ 	if (!mux_bus) {
++		if (!mux_node)
++			return -ENODEV;
++
+ 		parent_bus_node = of_parse_phandle(mux_node,
+ 						   "mdio-parent-bus", 0);
+ 
+@@ -133,16 +134,20 @@ int mdio_mux_init(struct device *dev,
+ 	pb->mii_bus = parent_bus;
+ 
+ 	ret_val = -ENODEV;
+-	for_each_available_child_of_node(mux_node, child_bus_node) {
+-		int v;
++	device_for_each_child_node(dev, child_bus_node) {
++		u32 v;
++		u32 phy_mask;
+ 
+-		r = of_property_read_u32(child_bus_node, "reg", &v);
++		r = fwnode_property_read_u32(child_bus_node, "reg", &v);
+ 		if (r) {
+ 			dev_err(dev,
+ 				"Error: Failed to find reg for child %pOF\n",
+ 				child_bus_node);
+ 			continue;
+ 		}
++		r = fwnode_property_read_u32(child_bus_node, "phy_mask", &phy_mask);
++		if (r)
++			phy_mask = 0;
+ 
+ 		cb = devm_kzalloc(dev, sizeof(*cb), GFP_KERNEL);
+ 		if (!cb) {
+@@ -166,7 +171,11 @@ int mdio_mux_init(struct device *dev,
+ 		cb->mii_bus->parent = dev;
+ 		cb->mii_bus->read = mdio_mux_read;
+ 		cb->mii_bus->write = mdio_mux_write;
+-		r = of_mdiobus_register(cb->mii_bus, child_bus_node);
++		cb->mii_bus->phy_mask = phy_mask;
++		if (is_of_node(child_bus_node))
++			r = of_mdiobus_register(cb->mii_bus, to_of_node(child_bus_node));
++		else
++			r = mdiobus_register(cb->mii_bus);
+ 		if (r) {
+ 			dev_err(dev,
+ 				"Error: Failed to register MDIO bus for child %pOF\n",

--- a/patch/cisco-mtd-part.patch
+++ b/patch/cisco-mtd-part.patch
@@ -1,0 +1,18 @@
+commit fb93f739e32768a78a063901ff9c89749deca530
+Author: Billie R Alsup <balsup@cisco.com>
+Date:   Wed Aug 19 14:24:55 2020 -0700
+
+    Prefer cisco-acpi-part partitioner over ofpart
+
+diff --git a/drivers/mtd/mtdpart.c b/drivers/mtd/mtdpart.c
+index 10c5336..fd9b134 100644
+--- a/drivers/mtd/mtdpart.c
++++ b/drivers/mtd/mtdpart.c
+@@ -821,6 +821,7 @@ EXPORT_SYMBOL_GPL(deregister_mtd_parser);
+  */
+ static const char * const default_mtd_part_types[] = {
+ 	"cmdlinepart",
++	"cisco-acpi-mtd-part",
+ 	"ofpart",
+ 	NULL
+ };

--- a/patch/cisco-pca953x-acpi-line-names.patch
+++ b/patch/cisco-pca953x-acpi-line-names.patch
@@ -1,0 +1,33 @@
+commit e0df284aa573de5310f2392cc48a9dc4e23b68c1
+Author: Billie R Alsup <balsup@cisco.com>
+Date:   Mon May 13 11:48:44 2019 -0700
+
+    Assign pin names from ACPI
+
+diff --git a/drivers/gpio/gpio-pca953x.c b/drivers/gpio/gpio-pca953x.c
+index fe731f0..ec3a0d7 100644
+--- a/drivers/gpio/gpio-pca953x.c
++++ b/drivers/gpio/gpio-pca953x.c
+@@ -793,6 +793,22 @@ static int pca953x_probe(struct i2c_client *client,
+ 		}
+ 	}
+ 
++        if (!chip->names) {
++	    int ngpio = chip->driver_data & PCA_GPIO_MASK;
++            ret = device_property_read_string_array(&client->dev, "gpio-line-names", NULL, 0);
++            if (ret < 0) {
++		dev_err(&client->dev, "no gpio-line-names property; ret %d", ret);
++            } else if (ret != ngpio) {
++		dev_err(&client->dev, "gpio-line-names %d do not match ngpios %d", ret, ngpio);
++            } else {
++                chip->names = devm_kzalloc(&client->dev, sizeof(*chip->names) * ngpio, GFP_KERNEL);
++                if (chip->names) {
++                    device_property_read_string_array(&client->dev, "gpio-line-names",
++                                                      (const char**)chip->names, ngpio);
++                }
++            }
++        }
++
+ 	mutex_init(&chip->i2c_lock);
+ 	/*
+ 	 * In case we have an i2c-mux controlled by a GPIO provided by an

--- a/patch/cisco-pmbus-driver-add-support-for-additional-temp-sensor.patch
+++ b/patch/cisco-pmbus-driver-add-support-for-additional-temp-sensor.patch
@@ -1,0 +1,108 @@
+From 28e70912210fae67f8979d7dd88e1f8e4783627f Mon Sep 17 00:00:00 2001
+From: Madhava Reddy Siddareddygari <msiddare@cisco.com>
+Date: Fri, 26 Mar 2021 10:51:45 -0700
+Subject: [PATCH] pmbus driver update to add support for additional temp4
+ sensor
+
+---
+ drivers/hwmon/pmbus/pmbus.c      |  4 +++-
+ drivers/hwmon/pmbus/pmbus.h      |  3 +++
+ drivers/hwmon/pmbus/pmbus_core.c | 38 ++++++++++++++++++++++++++++++++
+ 3 files changed, 44 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/hwmon/pmbus/pmbus.c b/drivers/hwmon/pmbus/pmbus.c
+index 4db0400b7..1ce0e00d0 100644
+--- a/drivers/hwmon/pmbus/pmbus.c
++++ b/drivers/hwmon/pmbus/pmbus.c
+@@ -66,8 +66,10 @@ static void pmbus_find_sensor_groups(struct i2c_client *client,
+ 		info->func[0] |= PMBUS_HAVE_TEMP2;
+ 	if (pmbus_check_word_register(client, 0, PMBUS_READ_TEMPERATURE_3))
+ 		info->func[0] |= PMBUS_HAVE_TEMP3;
++	if (pmbus_check_word_register(client, 0, PMBUS_READ_TEMPERATURE_4))
++		info->func[0] |= PMBUS_HAVE_TEMP4;
+ 	if (info->func[0] & (PMBUS_HAVE_TEMP | PMBUS_HAVE_TEMP2
+-			     | PMBUS_HAVE_TEMP3)
++			     | PMBUS_HAVE_TEMP3 | PMBUS_HAVE_TEMP4)
+ 	    && pmbus_check_byte_register(client, 0,
+ 					 PMBUS_STATUS_TEMPERATURE))
+ 			info->func[0] |= PMBUS_HAVE_STATUS_TEMP;
+diff --git a/drivers/hwmon/pmbus/pmbus.h b/drivers/hwmon/pmbus/pmbus.h
+index 5481ff9f8..a7562d727 100644
+--- a/drivers/hwmon/pmbus/pmbus.h
++++ b/drivers/hwmon/pmbus/pmbus.h
+@@ -130,6 +130,8 @@ enum pmbus_regs {
+ 	PMBUS_MFR_DATE			= 0x9D,
+ 	PMBUS_MFR_SERIAL		= 0x9E,
+ 
++	PMBUS_READ_TEMPERATURE_4        = 0xDF,
++
+ /*
+  * Virtual registers.
+  * Useful to support attributes which are not supported by standard PMBus
+@@ -371,6 +373,7 @@ enum pmbus_sensor_classes {
+ #define PMBUS_HAVE_STATUS_VMON	BIT(19)
+ #define PMBUS_HAVE_PWM12	BIT(20)
+ #define PMBUS_HAVE_PWM34	BIT(21)
++#define PMBUS_HAVE_TEMP4	BIT(22)
+ 
+ #define PMBUS_PAGE_VIRTUAL	BIT(31)
+ 
+diff --git a/drivers/hwmon/pmbus/pmbus_core.c b/drivers/hwmon/pmbus/pmbus_core.c
+index b0b4f17c9..4f40fac1a 100644
+--- a/drivers/hwmon/pmbus/pmbus_core.c
++++ b/drivers/hwmon/pmbus/pmbus_core.c
+@@ -1754,6 +1754,32 @@ static const struct pmbus_limit_attr temp_limit_attrs3[] = {
+ 	}
+ };
+ 
++static const struct pmbus_limit_attr temp_limit_attrs4[] = {
++	{
++		.reg = PMBUS_UT_WARN_LIMIT,
++		.low = true,
++		.attr = "min",
++		.alarm = "min_alarm",
++		.sbit = PB_TEMP_UT_WARNING,
++	}, {
++		.reg = PMBUS_UT_FAULT_LIMIT,
++		.low = true,
++		.attr = "lcrit",
++		.alarm = "lcrit_alarm",
++		.sbit = PB_TEMP_UT_FAULT,
++	}, {
++		.reg = PMBUS_OT_WARN_LIMIT,
++		.attr = "max",
++		.alarm = "max_alarm",
++		.sbit = PB_TEMP_OT_WARNING,
++	}, {
++		.reg = PMBUS_OT_FAULT_LIMIT,
++		.attr = "crit",
++		.alarm = "crit_alarm",
++		.sbit = PB_TEMP_OT_FAULT,
++	}
++};
++
+ static const struct pmbus_sensor_attr temp_attributes[] = {
+ 	{
+ 		.reg = PMBUS_READ_TEMPERATURE_1,
+@@ -1791,6 +1817,18 @@ static const struct pmbus_sensor_attr temp_attributes[] = {
+ 		.gbit = PB_STATUS_TEMPERATURE,
+ 		.limit = temp_limit_attrs3,
+ 		.nlimit = ARRAY_SIZE(temp_limit_attrs3),
++	}, {
++		.reg = PMBUS_READ_TEMPERATURE_4,
++		.class = PSC_TEMPERATURE,
++		.paged = true,
++		.update = true,
++		.compare = true,
++		.func = PMBUS_HAVE_TEMP4,
++		.sfunc = PMBUS_HAVE_STATUS_TEMP,
++		.sbase = PB_STATUS_TEMP_BASE,
++		.gbit = PB_STATUS_TEMPERATURE,
++		.limit = temp_limit_attrs4,
++		.nlimit = ARRAY_SIZE(temp_limit_attrs4),
+ 	}
+ };
+ 
+-- 
+2.26.2.dirty
+

--- a/patch/cisco-pmbus_core_pec.patch
+++ b/patch/cisco-pmbus_core_pec.patch
@@ -1,0 +1,27 @@
+commit 23e50c33b5d80873673c9741665f2b667465a2b9
+Author: balsup <balsup@contoso.com>
+Date:   Thu Aug 13 23:49:43 2020 +0000
+
+    pmbus_core: do not enable PEC if adapter doesn't support it
+
+diff --git a/drivers/hwmon/pmbus/pmbus_core.c b/drivers/hwmon/pmbus/pmbus_core.c
+index 1d7f950..b0b4f17 100644
+--- a/drivers/hwmon/pmbus/pmbus_core.c
++++ b/drivers/hwmon/pmbus/pmbus_core.c
+@@ -2044,10 +2044,12 @@ static int pmbus_init_common(struct i2c_client *client, struct pmbus_data *data,
+ 		data->has_status_word = true;
+ 	}
+ 
+-	/* Enable PEC if the controller supports it */
+-	ret = i2c_smbus_read_byte_data(client, PMBUS_CAPABILITY);
+-	if (ret >= 0 && (ret & PB_CAPABILITY_ERROR_CHECK))
+-		client->flags |= I2C_CLIENT_PEC;
++	/* Enable PEC if the controller and bus support it */
++	if (i2c_check_functionality(client->adapter, I2C_FUNC_SMBUS_PEC)) {
++		ret = i2c_smbus_read_byte_data(client, PMBUS_CAPABILITY);
++		if (ret >= 0 && (ret & PB_CAPABILITY_ERROR_CHECK))
++			client->flags |= I2C_CLIENT_PEC;
++	}
+ 
+ 	if (data->info->pages)
+ 		pmbus_clear_faults(client);


### PR DESCRIPTION
Set of kernel patches required for building sonic-linux-kernel on cisco-8000 platform. 

The patch description is as follows: 

cisco-pca953x-acpi-line-names.patch:  instantiate i2c devices via acpi and hence assign an acpi node to the device
cisco-mdio-mux-support-acpi.patch is used to support acpi, by switching from the of set of apis to the fwnode set of apis.
cisco-pmbus_core_pec.patch: Checks if client device supports PEC, and if so, enable same in 
client.cisco-acpi-spi-nor.patch:  Adds an apci match table to the driver so that is can be transparently instantiated by acpi.
cisco-mtd-part.patch: Adds a named partition function for use when determining how to partition flash devices
cisco-ltc4306-peer.patch: This provides capability of two distinct ltc4306 devices, each with 8 channels, we present a single logical view of one logical device with 16 channels.  so when when we select a channel, we are always ensuring that the "other" ltc4306 has its channels disabled.  this mode is configured by using the special device name ltc4306x2 instead of ltc4306 when instantiating the device.
cisco-ds4424-null-of-node.patch: Removes a check for a null dev.of_node
cisco-add-support-for-ltc2979-chip.patch: Provides capability to add two more chip ids to the driver.
cisco-pmbus-driver-add-support-for-additional-temp-sensor.patch: Enables support for all sensors drivers as modules 