### PR TITLE
hwmon: (pmbus_core) Do not enable PEC if adapter doesn't

### DIFF
--- a/patch/cisco-hwmon-pmbus_core-pec-support-check.patch
+++ b/patch/cisco-hwmon-pmbus_core-pec-support-check.patch
@@ -1,35 +1,40 @@
-From ca2339d26b3473aa4f85006c5caff8eb01fd5435 Mon Sep 17 00:00:00 2001
+From a3e00e49a8647ea9ba6f08a36c1bf6884f91619a Mon Sep 17 00:00:00 2001
 From: Madhava Reddy Siddareddygari <msiddare@cisco.com>
-Date: Wed, 26 May 2021 11:25:14 -0700
-Subject: [PATCH] hwmon: (pmbus_core) Do not enable PEC if adapter doesn't
- support it
+Date: Tue, 1 Jun 2021 22:42:41 -0700
+Subject: [PATCH] hwmon: (pmbus_core) Check adapter PEC support
 
-Added code to check if i2c bus has capability to support PEC [ Packet Error Correction ] and enable it only if both controller and bus support it
+Currently, for Packet Error Checking (PEC) only the controller
+is checked for support. This causes problems on the cisco-8000
+platform where a SMBUS transaction errors are observed. This is
+because PEC has to be enabled only if both controller and
+adapter supports it.
 
-I2C_FUNC_SMBUS_PEC can be used to check PEC capability
+Added code to check PEC capability for adapter and enable it
+only if both controller and adapter supports PEC.
 
 Signed-off-by: Madhava Reddy Siddareddygari <msiddare@cisco.com>
 ---
- drivers/hwmon/pmbus/pmbus_core.c | 10 ++++++----
- 1 file changed, 6 insertions(+), 4 deletions(-)
+ drivers/hwmon/pmbus/pmbus_core.c | 10 +++++++---
+ 1 file changed, 7 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/hwmon/pmbus/pmbus_core.c b/drivers/hwmon/pmbus/pmbus_core.c
-index 1d7f950e6..16b20d48d 100644
+index df4a6de24..2f98b4785 100644
 --- a/drivers/hwmon/pmbus/pmbus_core.c
 +++ b/drivers/hwmon/pmbus/pmbus_core.c
-@@ -2044,10 +2044,12 @@ static int pmbus_init_common(struct i2c_client *client, struct pmbus_data *data,
+@@ -2082,10 +2082,14 @@ static int pmbus_init_common(struct i2c_client *client, struct pmbus_data *data,
  		data->has_status_word = true;
  	}
  
 -	/* Enable PEC if the controller supports it */
--	ret = i2c_smbus_read_byte_data(client, PMBUS_CAPABILITY);
++	/* Enable PEC if the controller and bus supports it */
+ 	ret = i2c_smbus_read_byte_data(client, PMBUS_CAPABILITY);
 -	if (ret >= 0 && (ret & PB_CAPABILITY_ERROR_CHECK))
 -		client->flags |= I2C_CLIENT_PEC;
-+	/* Enable PEC if the controller and bus supports it */
-+	if (i2c_check_functionality(client->adapter, I2C_FUNC_SMBUS_PEC)) {
-+		ret = i2c_smbus_read_byte_data(client, PMBUS_CAPABILITY);
-+		if (ret >= 0 && (ret & PB_CAPABILITY_ERROR_CHECK))
++	if (ret >= 0 && (ret & PB_CAPABILITY_ERROR_CHECK)) {
++		if (i2c_check_functionality(client->adapter,
++			I2C_FUNC_SMBUS_PEC)) {
 +			client->flags |= I2C_CLIENT_PEC;
++		}
 +	}
  
  	if (data->info->pages)

--- a/patch/cisco-hwmon-pmbus_core-pec-support-check.patch
+++ b/patch/cisco-hwmon-pmbus_core-pec-support-check.patch
@@ -1,0 +1,39 @@
+From ca2339d26b3473aa4f85006c5caff8eb01fd5435 Mon Sep 17 00:00:00 2001
+From: Madhava Reddy Siddareddygari <msiddare@cisco.com>
+Date: Wed, 26 May 2021 11:25:14 -0700
+Subject: [PATCH] hwmon: (pmbus_core) Do not enable PEC if adapter doesn't
+ support it
+
+Added code to check if i2c bus has capability to support PEC [ Packet Error Correction ] and enable it only if both controller and bus support it
+
+I2C_FUNC_SMBUS_PEC can be used to check PEC capability
+
+Signed-off-by: Madhava Reddy Siddareddygari <msiddare@cisco.com>
+---
+ drivers/hwmon/pmbus/pmbus_core.c | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/hwmon/pmbus/pmbus_core.c b/drivers/hwmon/pmbus/pmbus_core.c
+index 1d7f950e6..16b20d48d 100644
+--- a/drivers/hwmon/pmbus/pmbus_core.c
++++ b/drivers/hwmon/pmbus/pmbus_core.c
+@@ -2044,10 +2044,12 @@ static int pmbus_init_common(struct i2c_client *client, struct pmbus_data *data,
+ 		data->has_status_word = true;
+ 	}
+ 
+-	/* Enable PEC if the controller supports it */
+-	ret = i2c_smbus_read_byte_data(client, PMBUS_CAPABILITY);
+-	if (ret >= 0 && (ret & PB_CAPABILITY_ERROR_CHECK))
+-		client->flags |= I2C_CLIENT_PEC;
++	/* Enable PEC if the controller and bus supports it */
++	if (i2c_check_functionality(client->adapter, I2C_FUNC_SMBUS_PEC)) {
++		ret = i2c_smbus_read_byte_data(client, PMBUS_CAPABILITY);
++		if (ret >= 0 && (ret & PB_CAPABILITY_ERROR_CHECK))
++			client->flags |= I2C_CLIENT_PEC;
++	}
+ 
+ 	if (data->info->pages)
+ 		pmbus_clear_faults(client);
+-- 
+2.26.2
+


### PR DESCRIPTION
 support it

Added code to check if i2c bus has capability to support PEC [ Packet Error Correction ] and enable it only if both controller and bus support PEC

I2C_FUNC_SMBUS_PEC can be used to check PEC capability

Signed-off-by: Madhava Reddy Siddareddygari <msiddare@cisco.com>