### PR TITLE
[Marvell] CPU1 failure on continuous reboot

### DIFF
--- a/patch/armhf_secondary_boot_online.patch
+++ b/patch/armhf_secondary_boot_online.patch
@@ -1,0 +1,56 @@
+From 500d48948f43d18a07894b5fd4f891afbade1d79 Mon Sep 17 00:00:00 2001
+From: Antony Rheneus <arheneus@marvell.com>
+Date: Thu, 1 Jul 2021 20:34:01 +0530
+Subject: [PATCH 1/1] From 28c199cfda1746644211893b6614acbac970515b Mon Sep 17
+ 00:00:00 2001 Subject: [PATCH 1/1] CPU1 failed to come online
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Issue: On contiuous reboot once in a while CPU1 (secondary cpu) doesn't
+come online
+The issue comes after migrating to Debian gcc 8.3.6, the issue was not seen till gcc7
+
+Until introducing the Debian GCC 8.x version – the execution process didn’t influence 
+mmu intialization before starting the socondary processor.
+The new GCC version makes some optimizations that execute the SW faster and once in a while,
+causing the Secondary CORE to start while the MMU is still in the initialization stage.
+Once adding a slight delay right after the MMU initialization –
+compensate the optimized code and enables the MMU to init successfully before the 2nd CORE starts.
+
+Signed-off-by: Antony Rheneus <arheneus@marvell.com>
+---
+ arch/arm/mach-mvebu/platsmp-a9.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/arch/arm/mach-mvebu/platsmp-a9.c b/arch/arm/mach-mvebu/platsmp-a9.c
+index d715dec..9c076c6 100644
+--- a/arch/arm/mach-mvebu/platsmp-a9.c
++++ b/arch/arm/mach-mvebu/platsmp-a9.c
+@@ -17,12 +17,15 @@
+ #include <linux/of.h>
+ #include <linux/smp.h>
+ #include <linux/mbus.h>
++#include <linux/delay.h>
++#include <linux/completion.h>
+ #include <asm/smp_scu.h>
+ #include <asm/smp_plat.h>
+ #include "common.h"
+ #include "pmsu.h"
+ 
+ extern void mvebu_cortex_a9_secondary_startup(void);
++static DECLARE_COMPLETION(cpu_wait);
+ 
+ static int mvebu_cortex_a9_boot_secondary(unsigned int cpu,
+ 						    struct task_struct *idle)
+@@ -44,6 +47,7 @@ static int mvebu_cortex_a9_boot_secondary(unsigned int cpu,
+ 		mvebu_pmsu_set_cpu_boot_addr(hw_cpu, mvebu_cortex_a9_secondary_startup);
+ 	smp_wmb();
+ 
++	wait_for_completion_timeout(&cpu_wait, usecs_to_jiffies(10));
+ 	/*
+ 	 * Doing this before deasserting the CPUs is needed to wake up CPUs
+ 	 * in the offline state after using CPU hotplug.
+-- 
+2.7.4
+

--- a/patch/series
+++ b/patch/series
@@ -84,6 +84,10 @@ net-sch_generic-fix-the-missing-new-qdisc-assignment.patch
 0030-hwmon-Add-convience-macro-to-define-simple-static-se.patch
 0031-backport-nvme-Add-hardware-monitoring-support.patch
 0032-platform-mellanox-mlxreg-hotplug-Use-capability-regi.patch
+
+#
+# Marvell platform patches for 4.19
+armhf_secondary_boot_online.patch
 ############################################################
 #
 # Internal patches will be added below (placeholder)


### PR DESCRIPTION
 On continuous reboot, once in a while CPU1 (secondary cpu) doesn't come online. Issue seen on migrating to Debian gcc 8.3.6 from gcc7.
Until introducing the Debian GCC 8.x version – the execution process didn’t influence
mmu intialization before starting the socondary processor.
The new GCC version makes some optimizations that execute the SW faster and once in a while,
causing the Secondary CORE to start while the MMU is still in the initialization stage.
Once adding a slight delay right after the MMU initialization –
compensate the optimized code and enables the MMU to init successfully before the 2nd CORE starts.

Signed-off-by: Rajkumar Pennadam Ramamoorthy <rpennadamram@marvell.com>