### PR TITLE
Increase optoe's write-max to support i2c block write

### DIFF
--- a/patch/driver-support-optoe-write-max.patch
+++ b/patch/driver-support-optoe-write-max.patch
@@ -1,0 +1,22 @@
+diff --git a/drivers/misc/eeprom/optoe.c b/drivers/misc/eeprom/optoe.c
+index 16287fdc5..61c408a84 100644
+--- a/drivers/misc/eeprom/optoe.c
++++ b/drivers/misc/eeprom/optoe.c
+@@ -1069,7 +1069,7 @@ static int optoe_probe(struct i2c_client *client,
+ 		 * 2 byte writes are acceptable for PE and Vout changes per
+ 		 * Application Note AN-2071.
+ 		 */
+-		unsigned int write_max = 1;
++		unsigned int write_max = 32;
+ 
+ 		optoe->bin.write = optoe_bin_write;
+ 		optoe->bin.attr.mode |= 0200;
+@@ -1131,6 +1131,8 @@ static int optoe_probe(struct i2c_client *client,
+ 	dev_info(&client->dev, "%zu byte %s EEPROM, %s\n",
+ 		optoe->bin.size, client->name,
+ 		optoe->bin.write ? "read/write" : "read-only");
++    printk(KERN_ERR "$$$optoe_probe(): %zu byte %s EEPROM, write_max=%u\n",
++            optoe->bin.size, client->name, optoe->write_max);
+ 
+ 	if (use_smbus == I2C_SMBUS_WORD_DATA ||
+ 	    use_smbus == I2C_SMBUS_BYTE_DATA) {

--- a/patch/driver-support-optoe-write-max.patch
+++ b/patch/driver-support-optoe-write-max.patch
@@ -1,46 +1,86 @@
-From 83573e4c3171b528a4516caf3483cfccf90b9a32 Mon Sep 17 00:00:00 2001
+From ca9daf437f0910493a6eb8ced900662223ea3cf7 Mon Sep 17 00:00:00 2001
 From: Prince George <prgeor@microsoft.com>
-Date: Wed, 4 Aug 2021 10:06:18 +0000
-Subject: [PATCH] Increase optoe's write-max to support i2c block write
+Date: Mon, 16 Aug 2021 16:04:15 +0000
+Subject: [PATCH] Dynamic write_max support for optoe driver  
+ In current optoe driver, the value of write_max is  hardcoded to one byte.  
+ CMIS spec supports firmware upgrade on QSFP-DD transceivers which means  
+ there is significant overhead due to this one byte write limit when a
+ platform wants to upgrade the firmware over an i2c bus at 100Khz. 
+ The  overhead is more pronounced when a platform has shared master and 
+ platform needs to perform firmware upgrade  on multiple transceivers.
 
-In current optoe driver, the value of write_max is hardcoded to one byte.
-CMIS spec supports firmware upgrade on QSFP-DD transceivers which means
-there is significant overhead due to this one byte write limit when a
-platform wants to upgrade the firmware over an i2c bus at 100Khz. The
-overhead is more pronounced when a platform has shared master and
-platform needs to perform firmware upgrade on multiple transceivers.
+ Added sysfs file 'write_max' for each i2c device (that use optoe driver)
+ so that the platform can override the default write max which is one byte.
+
+ Test result:-
+ Firmware file of size 1.9MB takes ~ 33 mins with write-max size = 1 Byte
+ Firmware file of size 1.9MB takes ~ 8 mins with write-max size = 64 Bytes
 
 Signed-off-by: Prince George <prgeor@microsoft.com>
 ---
- drivers/misc/eeprom/optoe.c | 7 ++++---
- 1 file changed, 4 insertions(+), 3 deletions(-)
+ drivers/misc/eeprom/optoe.c | 36 ++++++++++++++++++++++++++++++++++++
+ 1 file changed, 36 insertions(+)
 
 diff --git a/drivers/misc/eeprom/optoe.c b/drivers/misc/eeprom/optoe.c
-index 16287fdc5..6cf61e645 100644
+index 16287fdc5..cacfb1848 100644
 --- a/drivers/misc/eeprom/optoe.c
 +++ b/drivers/misc/eeprom/optoe.c
-@@ -1069,7 +1069,7 @@ static int optoe_probe(struct i2c_client *client,
- 		 * 2 byte writes are acceptable for PE and Vout changes per
- 		 * Application Note AN-2071.
- 		 */
--		unsigned int write_max = 1;
-+		unsigned int write_max = 32;
+@@ -822,6 +822,39 @@ static int optoe_remove(struct i2c_client *client)
+ 	return 0;
+ }
  
- 		optoe->bin.write = optoe_bin_write;
- 		optoe->bin.attr.mode |= 0200;
-@@ -1128,9 +1128,10 @@ static int optoe_probe(struct i2c_client *client,
++static ssize_t show_dev_write_max_size(struct device *dev,
++			struct device_attribute *dattr, char *buf)
++{
++	struct i2c_client *client = to_i2c_client(dev);
++	struct optoe_data *optoe = i2c_get_clientdata(client);
++	ssize_t count;
++
++	mutex_lock(&optoe->lock);
++	count = sprintf(buf, "%u\n", optoe->write_max);
++	mutex_unlock(&optoe->lock);
++
++	return count;
++}
++
++static ssize_t set_dev_write_max_size(struct device *dev,
++			struct device_attribute *attr,
++			const char *buf, size_t count)
++{
++	struct i2c_client *client = to_i2c_client(dev);
++	struct optoe_data *optoe = i2c_get_clientdata(client);
++	int write_max_size;
++
++	if (kstrtouint(buf, 0, &write_max_size) != 0 ||
++		write_max_size < 1 || write_max_size > OPTOE_PAGE_SIZE)
++		return -EINVAL;
++
++	mutex_lock(&optoe->lock);
++	optoe->write_max = write_max_size;
++	mutex_unlock(&optoe->lock);
++
++	return count;
++}
++
+ static ssize_t show_dev_class(struct device *dev,
+ 			struct device_attribute *dattr, char *buf)
+ {
+@@ -928,12 +961,15 @@ static ssize_t set_port_name(struct device *dev,
+ static DEVICE_ATTR(port_name,  0644, show_port_name, set_port_name);
+ #endif  /* if NOT defined EEPROM_CLASS, the common case */
  
- 	i2c_set_clientdata(client, optoe);
++static DEVICE_ATTR(write_max, 0644, show_dev_write_max_size,
++					set_dev_write_max_size);
+ static DEVICE_ATTR(dev_class,  0644, show_dev_class, set_dev_class);
  
--	dev_info(&client->dev, "%zu byte %s EEPROM, %s\n",
-+	dev_info(&client->dev, "%zu byte %s EEPROM, %s write_max=%u\n",
- 		optoe->bin.size, client->name,
--		optoe->bin.write ? "read/write" : "read-only");
-+		optoe->bin.write ? "read/write" : "read-only",
-+		optoe->bin.size, client->name, optoe->write_max);
- 
- 	if (use_smbus == I2C_SMBUS_WORD_DATA ||
- 	    use_smbus == I2C_SMBUS_BYTE_DATA) {
+ static struct attribute *optoe_attrs[] = {
+ #ifndef EEPROM_CLASS
+ 	&dev_attr_port_name.attr,
+ #endif
++	&dev_attr_write_max.attr,
+ 	&dev_attr_dev_class.attr,
+ 	NULL,
+ };
 -- 
 2.17.1
 

--- a/patch/driver-support-optoe-write-max.patch
+++ b/patch/driver-support-optoe-write-max.patch
@@ -1,5 +1,22 @@
+From 83573e4c3171b528a4516caf3483cfccf90b9a32 Mon Sep 17 00:00:00 2001
+From: Prince George <prgeor@microsoft.com>
+Date: Wed, 4 Aug 2021 10:06:18 +0000
+Subject: [PATCH] Increase optoe's write-max to support i2c block write
+
+In current optoe driver, the value of write_max is hardcoded to one byte.
+CMIS spec supports firmware upgrade on QSFP-DD transceivers which means
+there is significant overhead due to this one byte write limit when a
+platform wants to upgrade the firmware over an i2c bus at 100Khz. The
+overhead is more pronounced when a platform has shared master and
+platform needs to perform firmware upgrade on multiple transceivers.
+
+Signed-off-by: Prince George <prgeor@microsoft.com>
+---
+ drivers/misc/eeprom/optoe.c | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
 diff --git a/drivers/misc/eeprom/optoe.c b/drivers/misc/eeprom/optoe.c
-index 16287fdc5..61c408a84 100644
+index 16287fdc5..6cf61e645 100644
 --- a/drivers/misc/eeprom/optoe.c
 +++ b/drivers/misc/eeprom/optoe.c
 @@ -1069,7 +1069,7 @@ static int optoe_probe(struct i2c_client *client,
@@ -11,12 +28,19 @@ index 16287fdc5..61c408a84 100644
  
  		optoe->bin.write = optoe_bin_write;
  		optoe->bin.attr.mode |= 0200;
-@@ -1131,6 +1131,8 @@ static int optoe_probe(struct i2c_client *client,
- 	dev_info(&client->dev, "%zu byte %s EEPROM, %s\n",
+@@ -1128,9 +1128,10 @@ static int optoe_probe(struct i2c_client *client,
+ 
+ 	i2c_set_clientdata(client, optoe);
+ 
+-	dev_info(&client->dev, "%zu byte %s EEPROM, %s\n",
++	dev_info(&client->dev, "%zu byte %s EEPROM, %s write_max=%u\n",
  		optoe->bin.size, client->name,
- 		optoe->bin.write ? "read/write" : "read-only");
-+    printk(KERN_ERR "$$$optoe_probe(): %zu byte %s EEPROM, write_max=%u\n",
-+            optoe->bin.size, client->name, optoe->write_max);
+-		optoe->bin.write ? "read/write" : "read-only");
++		optoe->bin.write ? "read/write" : "read-only",
++		optoe->bin.size, client->name, optoe->write_max);
  
  	if (use_smbus == I2C_SMBUS_WORD_DATA ||
  	    use_smbus == I2C_SMBUS_BYTE_DATA) {
+-- 
+2.17.1
+

--- a/patch/series
+++ b/patch/series
@@ -30,6 +30,7 @@ driver-support-optoe.patch
 driver-support-optoe-EOF_fix.patch
 driver-support-optoe-chunk-offset-fix.patch
 driver-support-optoe-QSFP_DD.patch
+driver-support-optoe-write-max.patch
 driver-net-tg3-add-param-short-preamble-and-reset.patch
 0001-hwmon-lm75-add-support-for-PCT2075.patch
 0004-dt-bindings-hwmon-Add-missing-documentation-for-lm75.patch


### PR DESCRIPTION
In current optoe driver, the value of write_max is hardcoded to one byte.

CMIS spec supports firmware upgrade on QSFP-DD transceivers which means there is significant overhead due to this one byte write limit when a platform wants to upgrade the firmware over an i2c bus at 100Khz.

The overhead is more pronounced when a platform has shared master and platform needs to perform firmware upgrade on multiple transceivers


Signed-off-by: Prince George <prgeor@microsoft.com>