### PR TITLE
Ported hwmon: (pmbus_core) Check adapter PEC support patch to 5.10.40 kernel

### DIFF
--- a/patch/cisco-hwmon-pmbus_core-pec-support-check.patch
+++ b/patch/cisco-hwmon-pmbus_core-pec-support-check.patch
@@ -1,6 +1,6 @@
-From a3e00e49a8647ea9ba6f08a36c1bf6884f91619a Mon Sep 17 00:00:00 2001
+From 8451736f488d2e24da57a6d6d8a3880bd023812b Mon Sep 17 00:00:00 2001
 From: Madhava Reddy Siddareddygari <msiddare@cisco.com>
-Date: Tue, 1 Jun 2021 22:42:41 -0700
+Date: Tue, 9 Nov 2021 10:54:31 -0800
 Subject: [PATCH] hwmon: (pmbus_core) Check adapter PEC support
 
 Currently, for Packet Error Checking (PEC) only the controller
@@ -14,31 +14,30 @@ only if both controller and adapter supports PEC.
 
 Signed-off-by: Madhava Reddy Siddareddygari <msiddare@cisco.com>
 ---
- drivers/hwmon/pmbus/pmbus_core.c | 10 +++++++---
- 1 file changed, 7 insertions(+), 3 deletions(-)
+ drivers/hwmon/pmbus/pmbus_core.c | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/hwmon/pmbus/pmbus_core.c b/drivers/hwmon/pmbus/pmbus_core.c
-index df4a6de24..2f98b4785 100644
+index 192442b3b..634615324 100644
 --- a/drivers/hwmon/pmbus/pmbus_core.c
 +++ b/drivers/hwmon/pmbus/pmbus_core.c
-@@ -2082,10 +2082,14 @@ static int pmbus_init_common(struct i2c_client *client, struct pmbus_data *data,
+@@ -2203,10 +2203,12 @@ static int pmbus_init_common(struct i2c_client *client, struct pmbus_data *data,
  		data->has_status_word = true;
  	}
  
 -	/* Enable PEC if the controller supports it */
-+	/* Enable PEC if the controller and bus supports it */
- 	ret = i2c_smbus_read_byte_data(client, PMBUS_CAPABILITY);
+-	ret = i2c_smbus_read_byte_data(client, PMBUS_CAPABILITY);
 -	if (ret >= 0 && (ret & PB_CAPABILITY_ERROR_CHECK))
 -		client->flags |= I2C_CLIENT_PEC;
-+	if (ret >= 0 && (ret & PB_CAPABILITY_ERROR_CHECK)) {
-+		if (i2c_check_functionality(client->adapter,
-+			I2C_FUNC_SMBUS_PEC)) {
++	/* Enable PEC if the controller and bus support it */
++	if (i2c_check_functionality(client->adapter, I2C_FUNC_SMBUS_PEC)) {
++		ret = i2c_smbus_read_byte_data(client, PMBUS_CAPABILITY);
++		if (ret >= 0 && (ret & PB_CAPABILITY_ERROR_CHECK))
 +			client->flags |= I2C_CLIENT_PEC;
-+		}
 +	}
  
- 	if (data->info->pages)
- 		pmbus_clear_faults(client);
+ 	/*
+ 	 * Check if the chip is write protected. If it is, we can not clear
 -- 
-2.26.2
+2.25.1
 

--- a/patch/cisco-hwmon-pmbus_core-pec-support-check.patch
+++ b/patch/cisco-hwmon-pmbus_core-pec-support-check.patch
@@ -12,6 +12,10 @@ adapter supports it.
 Added code to check PEC capability for adapter and enable it
 only if both controller and adapter supports PEC.
 
+This patch was applied to Linux 5.14 in commit
+4e5418f787ec56d7fe3c6efee486b8f508c58baf  
+(hwmon: (pmbus_core) Check adapter PEC support).
+
 Signed-off-by: Madhava Reddy Siddareddygari <msiddare@cisco.com>
 ---
  drivers/hwmon/pmbus/pmbus_core.c | 10 ++++++----

--- a/patch/series
+++ b/patch/series
@@ -95,6 +95,7 @@ cisco-mdio-mux-support-acpi.patch
 cisco-x86-gpio-config.patch
 cisco-acpi-spi-nor.patch
 cisco-Enable-static-memory-reservation-for-OIRable-PCIe-de.patch
+cisco-hwmon-pmbus_core-pec-support-check.patch
 
 #
 # Marvell platform patches for 4.19


### PR DESCRIPTION
Ported hwmon: (pmbus_core) Check adapter PEC support patch to 5.10.40 kernel.

When switch from Linux 4.19.x to 5.10.40 the patch was disabled, as it did not apply cleanly. Forward port it to Linux 5.10.40 and add it to the Linux 5.10 patch series.

Test on cisco-8000 platform
root@localhost:/home/cisco# show plat temp
Sensor Temperature High TH Low TH Crit High TH Crit Low TH Warning Timestamp
CPU_U17_P1P05V_TEMP 35.187 125 -5 135 -10 False 20211011 13:57:45
CPU_U17_PVCCIN_TEMP 34.937 125 -5 135 -10 False 20211011 13:57:45
CPU_U117_P1P2V_TEMP 30.75 125 -5 135 -10 False 20211011 13:57:46
CPU_U117_P1P05V_TEMP 31 125 -5 135 -10 False 20211011 13:57:46
DIMM_TEMP1 28.25 125 -5 135 -10 False 20211011 13:57:47
FAN_Sensor 32.375 97 -5 102 -10 False 20211011 13:57:45
MB_3_3V_L_TEMP_L1 33.187 125 -5 135 -10 False 20211011 13:57:47
MB_3_3V_L_TEMP_L2 33.187 125 -5 135 -10 False 20211011 13:57:47
MB_3_3V_R_VDDCK_TEMP_L1 34.187 125 -5 135 -10 False 20211011 13:57:46
MB_3_3V_R_VDDCK_TEMP_L2 48.312 125 -5 135 -10 False 20211011 13:57:46
MB_GB_CORE_TEMP_L1 43.312 110 -5 115 -10 False 20211011 13:57:47
MB_PORT_Sensor 22.563 120 -5 125 -10 False 20211011 13:57:45
MB_TMP421_Local 25 120 -5 125 -10 False 20211011 13:57:45
MB_VDDS_VDDA_TEMP_L1 48.125 125 -5 135 -10 False 20211011 13:57:46
MB_VDDS_VDDA_TEMP_L2 50.562 125 -5 135 -10 False 20211011 13:57:46
PSU0 HSNK_Temp1 28.75 91 -5 96 -10 False 20211011 13:57:47
PSU0 HSNK_Temp2 28.25 110 -5 115 -10 False 20211011 13:57:47
PSU0 Inlet_Temp 27.5 80 -5 85 -10 False 20211011 13:57:47
PSU0 Outlet_Temp 31.75 108 -5 110 -10 False 20211011 13:57:47
PSU1 HSNK_Temp1 29 91 -5 96 -10 False 20211011 13:57:47
PSU1 HSNK_Temp2 28.25 110 -5 115 -10 False 20211011 13:57:47
PSU1 Inlet_Temp 26.5 80 -5 85 -10 False 20211011 13:57:47
PSU1 Outlet_Temp 30.75 108 -5 110 -10 False 20211011 13:57:47
SSD_Temp 25 80 -5 85 -10 False 20211011 13:57:47
X86_CORE_0_T 37 125 -5 135 -10 False 20211011 13:57:45
X86_CORE_1_T 38 125 -5 135 -10 False 20211011 13:57:45
X86_CORE_2_T 37 125 -5 135 -10 False 20211011 13:57:45
X86_CORE_3_T 37 125 -5 135 -10 False 20211011 13:57:45
X86_PKG_TEMP 38 125 -5 135 -10 False 20211011 13:57:45
root@localhost:/home/cisco#

Signed-off-by: Madhava Reddy Siddareddygari <msiddare@cisco.com>