### PR TITLE
hwmon: (pmbus/ltc2978) Add support for new sensor

### DIFF
--- a/patch/cisco-add-support-for-ltc2979-chip.patch
+++ b/patch/cisco-add-support-for-ltc2979-chip.patch
@@ -1,0 +1,76 @@
+From b2a01dd5afd900448a31090cded7d9f2a378b990 Mon Sep 17 00:00:00 2001
+From: Madhava Reddy Siddareddygari <msiddare@cisco.com>
+Date: Sat, 25 Sep 2021 21:58:15 -0700
+Subject: [PATCH] hwmon: (pmbus/ltc2978) Add support for new sensor
+
+Current ltc2978 driver does not have support for device ltc2979.
+
+Added support for the sensor device ltc2979.
+Datasheet for the sensor is at followint path.
+www.analog.com/media/en/technical-documentation/data-sheets/2979f.pdf
+
+This chip is used for voltage sensors on cisco-8000 platform.
+
+Signed-off-by: Madhava Reddy Siddareddygari <msiddare@cisco.com>
+---
+ drivers/hwmon/pmbus/ltc2978.c | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/hwmon/pmbus/ltc2978.c b/drivers/hwmon/pmbus/ltc2978.c
+index 94eea2ac6..8cbaf3b83 100644
+--- a/drivers/hwmon/pmbus/ltc2978.c
++++ b/drivers/hwmon/pmbus/ltc2978.c
+@@ -27,7 +27,7 @@
+ #include <linux/regulator/driver.h>
+ #include "pmbus.h"
+ 
+-enum chips { ltc2974, ltc2975, ltc2977, ltc2978, ltc2980, ltc3880, ltc3882,
++enum chips { ltc2974, ltc2975, ltc2977, ltc2978, ltc2979, ltc2980, ltc3880, ltc3882,
+ 	ltc3883, ltc3886, ltc3887, ltm2987, ltm4675, ltm4676 };
+ 
+ /* Common for all chips */
+@@ -36,6 +36,8 @@ enum chips { ltc2974, ltc2975, ltc2977, ltc2978, ltc2980, ltc3880, ltc3882,
+ #define LTC2978_MFR_TEMPERATURE_PEAK	0xdf
+ #define LTC2978_MFR_SPECIAL_ID		0xe7	/* Undocumented on LTC3882 */
+ #define LTC2978_MFR_COMMON		0xef
++#define LTC2979_ID_A			0x8060
++#define LTC2979_ID_B			0x8070
+ 
+ /* LTC2974, LTC2975, LCT2977, LTC2980, LTC2978, and LTM2987 */
+ #define LTC2978_MFR_VOUT_MIN		0xfb
+@@ -503,6 +505,7 @@ static const struct i2c_device_id ltc2978_id[] = {
+ 	{"ltc2975", ltc2975},
+ 	{"ltc2977", ltc2977},
+ 	{"ltc2978", ltc2978},
++	{"ltc2979", ltc2979},
+ 	{"ltc2980", ltc2980},
+ 	{"ltc3880", ltc3880},
+ 	{"ltc3882", ltc3882},
+@@ -569,6 +572,8 @@ static int ltc2978_get_id(struct i2c_client *client)
+ 		return ltc2977;
+ 	else if (chip_id == LTC2978_ID_REV1 || chip_id == LTC2978_ID_REV2)
+ 		return ltc2978;
++	else if (chip_id == LTC2979_ID_A || chip_id == LTC2979_ID_B)
++		return ltc2979;
+ 	else if (chip_id == LTC2980_ID_A || chip_id == LTC2980_ID_B)
+ 		return ltc2980;
+ 	else if (chip_id == LTC3880_ID)
+@@ -668,6 +673,7 @@ static int ltc2978_probe(struct i2c_client *client,
+ 		break;
+ 	case ltc2977:
+ 	case ltc2978:
++	case ltc2979:
+ 	case ltc2980:
+ 	case ltm2987:
+ 		info->read_word_data = ltc2978_read_word_data;
+@@ -761,6 +767,7 @@ static const struct of_device_id ltc2978_of_match[] = {
+ 	{ .compatible = "lltc,ltc2975" },
+ 	{ .compatible = "lltc,ltc2977" },
+ 	{ .compatible = "lltc,ltc2978" },
++	{ .compatible = "lltc,ltc2979" },
+ 	{ .compatible = "lltc,ltc2980" },
+ 	{ .compatible = "lltc,ltc3880" },
+ 	{ .compatible = "lltc,ltc3882" },
+-- 
+2.26.2.dirty
+

--- a/patch/series
+++ b/patch/series
@@ -82,6 +82,8 @@ net-sch_generic-fix-the-missing-new-qdisc-assignment.patch
 0031-backport-nvme-Add-hardware-monitoring-support.patch
 0032-platform-mellanox-mlxreg-hotplug-Use-capability-regi.patch
 
+cisco-add-support-for-ltc2979-chip.patch
+
 #
 # Marvell platform patches for 4.19
 armhf_secondary_boot_online.patch


### PR DESCRIPTION
Current ltc2978 driver does not have support for device ltc2979.

Added support for the sensor device ltc2979.
Datasheet for the sensor is at followint path.
www.analog.com/media/en/technical-documentation/data-sheets/2979f.pdf

This chip is used for voltage sensors on cisco-8000 platform.

Signed-off-by: Madhava Reddy Siddareddygari <msiddare@cisco.com>