### PR TITLE
Cisco/patches

### DIFF
--- a/patch/cisco-Enable-static-memory-reservation-for-OIRable-PCIe-de.patch
+++ b/patch/cisco-Enable-static-memory-reservation-for-OIRable-PCIe-de.patch
@@ -1,0 +1,226 @@
+From 22bee632f2564c6265ff040373b70e953da2dff8 Mon Sep 17 00:00:00 2001
+From: Madhava Reddy Siddareddygari <msiddare@cisco.com>
+Date: Mon, 20 Sep 2021 16:05:57 -0700
+Subject: [PATCH] drivers/pci: Reserve address space for devices behind bridges
+
+Cisco data path devices are powered off by default, they will not be
+available at BIOS stage and memory for these devices is not reserved.
+
+This patch will reserve address space for data path devices that are
+behind PCIe bridge, so that when devices are available PCIe subsystem
+will be assign the address with in the specified range.
+
+Signed-off-by: Madhava Reddy Siddareddygari <msiddare@cisco.com>
+---
+ drivers/pci/setup-bus.c | 174 ++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 174 insertions(+)
+
+diff --git a/drivers/pci/setup-bus.c b/drivers/pci/setup-bus.c
+index 87c8190de..b3265cfb9 100644
+--- a/drivers/pci/setup-bus.c
++++ b/drivers/pci/setup-bus.c
+@@ -942,6 +942,156 @@ static inline resource_size_t calculate_mem_align(resource_size_t *aligns,
+ 	return min_align;
+ }
+ 
++#define PLX_RES_MAGIC_VALUE            0xABBA
++#define PLX_RES_DS_PORT_REG0           0xC6C
++#define PLX_RES_DS_PORT_REG1           0xC70
++#define PLX_RES_MAGIC_OFFSET           0xC76
++#define PLX_RES_NP_MASK                0x1
++#define PLX_RES_P_MASK                 0x1F
++
++static struct pci_dev *
++plx_find_nt_device(struct pci_bus *bus, unsigned short brg_dev_id)
++{
++	struct pci_dev *dev, *nt_virt_dev = NULL;
++	struct pci_bus *child_bus;
++	unsigned short vendor, devid, class;
++
++	if (!bus)
++		return NULL;
++
++	list_for_each_entry(child_bus, &bus->children, node) {
++		list_for_each_entry(dev, &child_bus->devices, bus_list) {
++			vendor = dev->vendor;
++			devid = dev->device;
++			class = dev->class >> 8;
++
++			if ((vendor == PCI_VENDOR_ID_PLX) &&
++				(brg_dev_id == devid) &&
++				(class == PCI_CLASS_BRIDGE_OTHER)) {
++					dev_dbg(&dev->dev,
++						"Found NT device 0x%x\n",
++						devid);
++					nt_virt_dev = dev;
++					break;
++			}
++		}
++
++		if (nt_virt_dev)
++			break;
++	}
++	return nt_virt_dev;
++}
++
++static resource_size_t
++pci_get_plx_downstream_res_size(struct pci_bus *bus,
++				unsigned long res_type)
++{
++	int depth = 0;
++	resource_size_t size = 0;
++	struct pci_dev *dev = bus->self;
++	struct pci_bus *tmp_bus;
++	struct pci_dev *nt_virt_dev;
++	u16 res_magic = 0;
++
++	/*
++	 * 32 bits to store the memory requirement for PLX ports.'
++	 * Following is the layout:
++	 * np32_0:1;  --> non-prefetchable port 0
++	 * p64_0:5;   --> prefetchable port 0
++	 * np32_1:1;  --> non-prefetchable port 1
++	 * p64_1:5;   --> prefetchable port 1
++	 * np32_2:1;  --> non-prefetchable port 2
++	 * p64_2:5;   --> prefetchable port 2
++	 * np32_3:1;  --> non-prefetchable port 3
++	 * p64_3:5;   --> prefetchable port 3
++	 * np32_4:1;  --> non-prefetchable port 4
++	 * p64_4:5;   --> prefetchable port 4
++	 * reserved:2;
++	 */
++	unsigned int port_bitmap;
++
++	u32 mem_res_bitmap = 0;
++	unsigned int ds_port_offset = 0;
++	unsigned short multiplier = 0;
++	unsigned short np_size = 0;
++
++	/*
++	 * PLX8713 used on FC4 and FC8
++	 * PLX8725 used on FC12 and FC18
++	 */
++	if (!dev || dev->vendor != PCI_VENDOR_ID_PLX ||
++		((dev->device & 0xFF00) != 0x8700))
++		return size;
++
++	tmp_bus = bus;
++	while (tmp_bus->parent) {
++		tmp_bus = tmp_bus->parent;
++		depth++;
++	}
++
++	/* Only for Second level bridges */
++	if (depth != 5)
++		return size;
++
++	nt_virt_dev = plx_find_nt_device(bus->parent, 0x87b0);
++	if (nt_virt_dev) {
++		pci_read_config_word(nt_virt_dev, PLX_RES_MAGIC_OFFSET,
++					&res_magic);
++		dev_dbg(&nt_virt_dev->dev,
++			"Magic offset of 0x%x found in NT device\n", 
++			res_magic);
++	}
++
++	if (res_magic == PLX_RES_MAGIC_VALUE) {
++		/*
++		 * The pacifics are connected on PLX ports:
++		 * FC4 and FC8: #3, #4
++		 * FC12       : #3, #4, #5
++		 * FC18       : #3, #4, #5, #11
++		 */
++
++		/* Calculate resource based on EEPROM values */
++		ds_port_offset = (bus->number - bus->parent->number) - 1;
++		if (ds_port_offset < 5) {
++			pci_read_config_dword(nt_virt_dev,
++				PLX_RES_DS_PORT_REG0, &mem_res_bitmap);
++		} else {
++			ds_port_offset -= 5;
++			pci_read_config_dword(nt_virt_dev,
++				PLX_RES_DS_PORT_REG1, &mem_res_bitmap);
++		}
++		port_bitmap = mem_res_bitmap;
++		dev_dbg(&bus->dev, "Port offset: 0x%x, res bitmap 0x%x\n",
++				ds_port_offset, mem_res_bitmap);
++
++		if (ds_port_offset < 5) {
++			u8 m[] = { 26, 20, 14, 8, 2 };
++			u8 s[] = { 31, 25, 19, 13, 7 };
++
++			multiplier = (port_bitmap >> m[ds_port_offset])
++					& PLX_RES_P_MASK;
++			np_size = (port_bitmap >> s[ds_port_offset])
++					& PLX_RES_NP_MASK;
++
++			dev_dbg(&bus->dev, "Multiplier: %d, np_size: %d\n",
++					multiplier, np_size);
++
++			if (res_type & IORESOURCE_PREFETCH) {
++				size = 0x100000 << (multiplier - 1);
++				dev_dbg(&bus->dev,
++					"Pref Multiplier %d, Size 0x%llx\n",
++					multiplier, (long long) size);
++			} else if (np_size) {
++				size = 0x100000;
++				dev_dbg(&bus->dev,
++					"NP Size 0x%llx\n", (long long) size);
++			}
++		}
++	}
++
++	return size;
++}
++
+ /**
+  * pbus_size_mem() - size the memory window of a given bus
+  *
+@@ -976,6 +1126,7 @@ static int pbus_size_mem(struct pci_bus *bus, unsigned long mask,
+ 	resource_size_t children_add_size = 0;
+ 	resource_size_t children_add_align = 0;
+ 	resource_size_t add_align = 0;
++	unsigned int dev_count = 0;
+ 
+ 	if (!b_res)
+ 		return -ENOSPC;
+@@ -987,6 +1138,7 @@ static int pbus_size_mem(struct pci_bus *bus, unsigned long mask,
+ 	list_for_each_entry(dev, &bus->devices, bus_list) {
+ 		int i;
+ 
++		dev_count++;
+ 		for (i = 0; i < PCI_NUM_RESOURCES; i++) {
+ 			struct resource *r = &dev->resource[i];
+ 			resource_size_t r_size;
+@@ -1040,6 +1192,28 @@ static int pbus_size_mem(struct pci_bus *bus, unsigned long mask,
+ 		}
+ 	}
+ 
++	/* Static allocation for Cisco Fabric Card pacific */
++	if (!size && !dev_count) {
++		size = pci_get_plx_downstream_res_size(bus, type);
++		if (size) {
++			order = __ffs(size);
++			dev_dbg(&bus->self->dev,
++				"order for %llx is %u\n",
++				(long long) size, order);
++			if (order >= 20) {
++				order -= 20;
++				if ((order < ARRAY_SIZE(aligns)) &&
++					(order > max_order)) {
++					max_order = order;
++					dev_dbg(&bus->self->dev,
++						"max_order reset to %d;"
++						"size %zx\n",
++						max_order, (size_t)size);
++				}
++			}
++		}
++	}
++
+ 	min_align = calculate_mem_align(aligns, max_order);
+ 	min_align = max(min_align, window_alignment(bus, b_res->flags));
+ 	size0 = calculate_memsize(size, min_size, 0, resource_size(b_res), min_align);
+-- 
+2.26.2
+

--- a/patch/cisco-acpi-spi-nor.patch
+++ b/patch/cisco-acpi-spi-nor.patch
@@ -1,0 +1,54 @@
+From cac7ee957753518f366b7afa4afa13f528af71f5 Mon Sep 17 00:00:00 2001
+From: Madhava Reddy Siddareddygari <msiddare@cisco.com>
+Date: Tue, 7 Sep 2021 15:57:12 -0700
+Subject: [PATCH] mtd: m25p80 spi driver update to support ACPI table match
+
+Current m25p80 spi nor driver does not support ACPI table match.
+Configuration done through ACPI tables is not recognized by driver.
+Cisco 8000 platform configures NOR flash partition information
+through ACPI table which is not recognized by m25p80.
+
+Added support in m25p80 to perform ACPI table match.
+
+Signed-off-by: Madhava Reddy Siddareddygari <msiddare@cisco.com>
+---
+ drivers/mtd/devices/m25p80.c | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/drivers/mtd/devices/m25p80.c b/drivers/mtd/devices/m25p80.c
+index c4a1d04b8..df21dd79f 100644
+--- a/drivers/mtd/devices/m25p80.c
++++ b/drivers/mtd/devices/m25p80.c
+@@ -22,6 +22,7 @@
+ 
+ #include <linux/mtd/mtd.h>
+ #include <linux/mtd/partitions.h>
++#include <linux/acpi.h>
+ 
+ #include <linux/spi/spi.h>
+ #include <linux/spi/spi-mem.h>
+@@ -319,11 +320,21 @@ static const struct of_device_id m25p_of_table[] = {
+ };
+ MODULE_DEVICE_TABLE(of, m25p_of_table);
+ 
++#ifdef CONFIG_ACPI
++static const struct acpi_device_id m25p_acpi_table[] = {
++       { "JEDEC,SPI-NOR", 0 },
++       { "ACPI0000", 0 },
++       {}
++};
++MODULE_DEVICE_TABLE(acpi, m25p_acpi_table);
++#endif
++
+ static struct spi_mem_driver m25p80_driver = {
+ 	.spidrv = {
+ 		.driver = {
+ 			.name	= "m25p80",
+ 			.of_match_table = m25p_of_table,
++			.acpi_match_table = ACPI_PTR(m25p_acpi_table),
+ 		},
+ 		.id_table	= m25p_ids,
+ 	},
+-- 
+2.26.2
+

--- a/patch/cisco-add-support-for-ltc2979-chip.patch
+++ b/patch/cisco-add-support-for-ltc2979-chip.patch
@@ -1,0 +1,76 @@
+From b2a01dd5afd900448a31090cded7d9f2a378b990 Mon Sep 17 00:00:00 2001
+From: Madhava Reddy Siddareddygari <msiddare@cisco.com>
+Date: Sat, 25 Sep 2021 21:58:15 -0700
+Subject: [PATCH] hwmon: (pmbus/ltc2978) Add support for new sensor
+
+Current ltc2978 driver does not have support for device ltc2979.
+
+Added support for the sensor device ltc2979.
+Datasheet for the sensor is at followint path.
+www.analog.com/media/en/technical-documentation/data-sheets/2979f.pdf
+
+This chip is used for voltage sensors on cisco-8000 platform.
+
+Signed-off-by: Madhava Reddy Siddareddygari <msiddare@cisco.com>
+---
+ drivers/hwmon/pmbus/ltc2978.c | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/hwmon/pmbus/ltc2978.c b/drivers/hwmon/pmbus/ltc2978.c
+index 94eea2ac6..8cbaf3b83 100644
+--- a/drivers/hwmon/pmbus/ltc2978.c
++++ b/drivers/hwmon/pmbus/ltc2978.c
+@@ -27,7 +27,7 @@
+ #include <linux/regulator/driver.h>
+ #include "pmbus.h"
+ 
+-enum chips { ltc2974, ltc2975, ltc2977, ltc2978, ltc2980, ltc3880, ltc3882,
++enum chips { ltc2974, ltc2975, ltc2977, ltc2978, ltc2979, ltc2980, ltc3880, ltc3882,
+ 	ltc3883, ltc3886, ltc3887, ltm2987, ltm4675, ltm4676 };
+ 
+ /* Common for all chips */
+@@ -36,6 +36,8 @@ enum chips { ltc2974, ltc2975, ltc2977, ltc2978, ltc2980, ltc3880, ltc3882,
+ #define LTC2978_MFR_TEMPERATURE_PEAK	0xdf
+ #define LTC2978_MFR_SPECIAL_ID		0xe7	/* Undocumented on LTC3882 */
+ #define LTC2978_MFR_COMMON		0xef
++#define LTC2979_ID_A			0x8060
++#define LTC2979_ID_B			0x8070
+ 
+ /* LTC2974, LTC2975, LCT2977, LTC2980, LTC2978, and LTM2987 */
+ #define LTC2978_MFR_VOUT_MIN		0xfb
+@@ -503,6 +505,7 @@ static const struct i2c_device_id ltc2978_id[] = {
+ 	{"ltc2975", ltc2975},
+ 	{"ltc2977", ltc2977},
+ 	{"ltc2978", ltc2978},
++	{"ltc2979", ltc2979},
+ 	{"ltc2980", ltc2980},
+ 	{"ltc3880", ltc3880},
+ 	{"ltc3882", ltc3882},
+@@ -569,6 +572,8 @@ static int ltc2978_get_id(struct i2c_client *client)
+ 		return ltc2977;
+ 	else if (chip_id == LTC2978_ID_REV1 || chip_id == LTC2978_ID_REV2)
+ 		return ltc2978;
++	else if (chip_id == LTC2979_ID_A || chip_id == LTC2979_ID_B)
++		return ltc2979;
+ 	else if (chip_id == LTC2980_ID_A || chip_id == LTC2980_ID_B)
+ 		return ltc2980;
+ 	else if (chip_id == LTC3880_ID)
+@@ -668,6 +673,7 @@ static int ltc2978_probe(struct i2c_client *client,
+ 		break;
+ 	case ltc2977:
+ 	case ltc2978:
++	case ltc2979:
+ 	case ltc2980:
+ 	case ltm2987:
+ 		info->read_word_data = ltc2978_read_word_data;
+@@ -761,6 +767,7 @@ static const struct of_device_id ltc2978_of_match[] = {
+ 	{ .compatible = "lltc,ltc2975" },
+ 	{ .compatible = "lltc,ltc2977" },
+ 	{ .compatible = "lltc,ltc2978" },
++	{ .compatible = "lltc,ltc2979" },
+ 	{ .compatible = "lltc,ltc2980" },
+ 	{ .compatible = "lltc,ltc3880" },
+ 	{ .compatible = "lltc,ltc3882" },
+-- 
+2.26.2.dirty
+

--- a/patch/cisco-ds4424-null-of-node.patch
+++ b/patch/cisco-ds4424-null-of-node.patch
@@ -1,0 +1,45 @@
+From ec513d48cc5b25b98c15ec2a47658c71b2231f95 Mon Sep 17 00:00:00 2001
+From: Madhava Reddy Siddareddygari <msiddare@cisco.com>
+Date: Sat, 25 Sep 2021 20:44:20 -0700
+Subject: [PATCH] iio: (dac/ds4424) Allow NULL of_node
+
+Cisco is using ACPI to read device configuration instead of
+OF (device-tree) for ds4424 device.
+
+Kernel is in a transition period in its support for ACPI
+(cisco using ACPI for kernel module configuration). The kernel
+makes a distinction between device tree (of_node) and ACPI
+(fw_node) in the device structure. It is unclear if they can be
+used together or not, but I can definitively say that we are only
+using ACPI and not device tree. In this particular driver, there
+was an explicit check for having a device tree node, even though no
+reference to the device tree was made within the driver. This caused
+the probe routine to fail with -ENODEV in cisco environment.
+
+This patch removes the check for of_node.
+
+Signed-off-by: Madhava Reddy Siddareddygari <msiddare@cisco.com>
+---
+ drivers/iio/dac/ds4424.c | 6 ------
+ 1 file changed, 6 deletions(-)
+
+diff --git a/drivers/iio/dac/ds4424.c b/drivers/iio/dac/ds4424.c
+index 714a97f91..ae9be7926 100644
+--- a/drivers/iio/dac/ds4424.c
++++ b/drivers/iio/dac/ds4424.c
+@@ -236,12 +236,6 @@ static int ds4424_probe(struct i2c_client *client,
+ 	indio_dev->dev.of_node = client->dev.of_node;
+ 	indio_dev->dev.parent = &client->dev;
+ 
+-	if (!client->dev.of_node) {
+-		dev_err(&client->dev,
+-				"Not found DT.\n");
+-		return -ENODEV;
+-	}
+-
+ 	data->vcc_reg = devm_regulator_get(&client->dev, "vcc");
+ 	if (IS_ERR(data->vcc_reg)) {
+ 		dev_err(&client->dev,
+-- 
+2.26.2
+

--- a/patch/cisco-hwmon-pmbus_core-pec-support-check.patch
+++ b/patch/cisco-hwmon-pmbus_core-pec-support-check.patch
@@ -1,0 +1,46 @@
+From a3e00e49a8647ea9ba6f08a36c1bf6884f91619a Mon Sep 17 00:00:00 2001
+From: Madhava Reddy Siddareddygari <msiddare@cisco.com>
+Date: Tue, 1 Jun 2021 22:42:41 -0700
+Subject: [PATCH] hwmon: (pmbus_core) Check adapter PEC support
+
+Currently, for Packet Error Checking (PEC) only the controller
+is checked for support. This causes problems on the cisco-8000
+platform where a SMBUS transaction errors are observed. This is
+because PEC has to be enabled only if both controller and
+adapter supports it.
+
+Added code to check PEC capability for adapter and enable it
+only if both controller and adapter supports PEC.
+
+This patch is bakported to 4.19.x kernel
+
+Signed-off-by: Madhava Reddy Siddareddygari <msiddare@cisco.com>
+---
+ drivers/hwmon/pmbus/pmbus_core.c | 10 +++++++---
+ 1 file changed, 7 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/hwmon/pmbus/pmbus_core.c b/drivers/hwmon/pmbus/pmbus_core.c
+index df4a6de24..2f98b4785 100644
+--- a/drivers/hwmon/pmbus/pmbus_core.c
++++ b/drivers/hwmon/pmbus/pmbus_core.c
+@@ -2082,10 +2082,14 @@ static int pmbus_init_common(struct i2c_client *client, struct pmbus_data *data,
+ 		data->has_status_word = true;
+ 	}
+ 
+-	/* Enable PEC if the controller supports it */
++	/* Enable PEC if the controller and bus supports it */
+ 	ret = i2c_smbus_read_byte_data(client, PMBUS_CAPABILITY);
+-	if (ret >= 0 && (ret & PB_CAPABILITY_ERROR_CHECK))
+-		client->flags |= I2C_CLIENT_PEC;
++	if (ret >= 0 && (ret & PB_CAPABILITY_ERROR_CHECK)) {
++		if (i2c_check_functionality(client->adapter,
++			I2C_FUNC_SMBUS_PEC)) {
++			client->flags |= I2C_CLIENT_PEC;
++		}
++	}
+ 
+ 	if (data->info->pages)
+ 		pmbus_clear_faults(client);
+-- 
+2.26.2
+

--- a/patch/cisco-mdio-mux-support-acpi.patch
+++ b/patch/cisco-mdio-mux-support-acpi.patch
@@ -1,0 +1,85 @@
+From 3f82482489e986fc3b0a38163902842d0c4fa2f2 Mon Sep 17 00:00:00 2001
+From: Madhava Reddy Siddareddygari <msiddare@cisco.com>
+Date: Tue, 15 Jun 2021 11:32:49 -0700
+Subject: [PATCH] support reading mdio config from ACPI tables
+
+Current mdio-mux does not support reading configuration
+from ACPI tables.
+
+cisco-8000 platform configures mdio phy config through ACPI
+tables.
+
+Added support in the mdio-mux driver to read from ACPI
+
+Signed-off-by: Madhava Reddy Siddareddygari <msiddare@cisco.com>
+---
+ drivers/net/phy/mdio-mux.c | 24 +++++++++++++++++++-----
+ 1 file changed, 19 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/net/phy/mdio-mux.c b/drivers/net/phy/mdio-mux.c
+index 0a86f1e4c..b6116f9af 100644
+--- a/drivers/net/phy/mdio-mux.c
++++ b/drivers/net/phy/mdio-mux.c
+@@ -93,7 +93,7 @@ int mdio_mux_init(struct device *dev,
+ 		  struct mii_bus *mux_bus)
+ {
+ 	struct device_node *parent_bus_node;
+-	struct device_node *child_bus_node;
++	struct fwnode_handle *child_bus_node;
+ 	int r, ret_val;
+ 	struct mii_bus *parent_bus;
+ 	struct mdio_mux_parent_bus *pb;
+@@ -103,6 +103,9 @@ int mdio_mux_init(struct device *dev,
+ 		return -ENODEV;
+ 
+ 	if (!mux_bus) {
++		if (!mux_node)
++			return -ENODEV;
++
+ 		parent_bus_node = of_parse_phandle(mux_node,
+ 						   "mdio-parent-bus", 0);
+ 
+@@ -133,10 +136,12 @@ int mdio_mux_init(struct device *dev,
+ 	pb->mii_bus = parent_bus;
+ 
+ 	ret_val = -ENODEV;
+-	for_each_available_child_of_node(mux_node, child_bus_node) {
+-		int v;
++	device_for_each_child_node(dev, child_bus_node) {
++		u32 v;
++		u32 phy_mask;
+ 
+-		r = of_property_read_u32(child_bus_node, "reg", &v);
++		r = fwnode_property_read_u32(child_bus_node, 
++				"reg", &v);
+ 		if (r) {
+ 			dev_err(dev,
+ 				"Error: Failed to find reg for child %pOF\n",
+@@ -144,6 +149,11 @@ int mdio_mux_init(struct device *dev,
+ 			continue;
+ 		}
+ 
++		r = fwnode_property_read_u32(child_bus_node, 
++				"phy_mask", &phy_mask);
++		if (r)
++			phy_mask = 0;
++
+ 		cb = devm_kzalloc(dev, sizeof(*cb), GFP_KERNEL);
+ 		if (!cb) {
+ 			ret_val = -ENOMEM;
+@@ -166,7 +176,11 @@ int mdio_mux_init(struct device *dev,
+ 		cb->mii_bus->parent = dev;
+ 		cb->mii_bus->read = mdio_mux_read;
+ 		cb->mii_bus->write = mdio_mux_write;
+-		r = of_mdiobus_register(cb->mii_bus, child_bus_node);
++		cb->mii_bus->phy_mask = phy_mask;
++		if (is_of_node(child_bus_node))
++			r = of_mdiobus_register(cb->mii_bus, to_of_node(child_bus_node));
++		else
++			r = mdiobus_register(cb->mii_bus);
+ 		if (r) {
+ 			dev_err(dev,
+ 				"Error: Failed to register MDIO bus for child %pOF\n",
+-- 
+2.26.2
+

--- a/patch/cisco-mtd-part.patch
+++ b/patch/cisco-mtd-part.patch
@@ -1,0 +1,33 @@
+From 157c059a2c639ecc69080ecb004a94e652467a4a Mon Sep 17 00:00:00 2001
+From: Madhava Reddy Siddareddygari <msiddare@cisco.com>
+Date: Tue, 8 Jun 2021 10:19:36 -0700
+Subject: [PATCH] mtd: Add support for reading partition data from ACPI
+
+Current mtd driver supports reading mtd partition information from
+command line and dts file, but cannot read partition information
+from ACPI files.
+
+Added code to support new partition type "acpipart" to
+default_mtd_part_types structure. This partition type can be used
+to configure mtd partition data in ACPI tables.
+
+Signed-off-by: Madhava Reddy Siddareddygari <msiddare@cisco.com>
+---
+ drivers/mtd/mtdpart.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/mtd/mtdpart.c b/drivers/mtd/mtdpart.c
+index 10c53364a..1ff24e5d9 100644
+--- a/drivers/mtd/mtdpart.c
++++ b/drivers/mtd/mtdpart.c
+@@ -822,6 +822,7 @@ EXPORT_SYMBOL_GPL(deregister_mtd_parser);
+ static const char * const default_mtd_part_types[] = {
+ 	"cmdlinepart",
+ 	"ofpart",
++	"acpipart",
+ 	NULL
+ };
+ 
+-- 
+2.26.2
+

--- a/patch/cisco-npu-disable-other-bars.patch
+++ b/patch/cisco-npu-disable-other-bars.patch
@@ -1,0 +1,77 @@
+From 7a2f6be308d25fd2451b455e6fdcb760bc7fc31b Mon Sep 17 00:00:00 2001
+From: Madhava Reddy Siddareddygari <msiddare@cisco.com>
+Date: Tue, 11 Jan 2022 15:17:02 -0800
+Subject: [PATCH] NPU disable unused PCI BAR's
+
+For Cisco Network Processing Unit ASIC only BAR0 is valid.
+Not disabling other BAR's was resulting in pci_enable_device
+function failure in P0 Pacific ASIC's. Further debugging and
+consultion with Hardware team, issue seems to be related to
+only P0 version of ASIC and workaround suggested is to disable
+unused PCI BAR.
+
+This patch disables unused PCI BAR of NPU ASIC.
+
+NPU is commonly used name for the packet forwarding ASIC's.
+
+Signed-off-by: Madhava Reddy Siddareddygari <msiddare@cisco.com>
+---
+ drivers/pci/quirks.c | 45 ++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 45 insertions(+)
+
+diff --git a/drivers/pci/quirks.c b/drivers/pci/quirks.c
+index af2149632..755c749b5 100644
+--- a/drivers/pci/quirks.c
++++ b/drivers/pci/quirks.c
+@@ -5462,3 +5462,48 @@ static void apex_pci_fixup_class(struct pci_dev *pdev)
+ }
+ DECLARE_PCI_FIXUP_CLASS_HEADER(0x1ac1, 0x089a,
+ 			       PCI_CLASS_NOT_DEFINED, 8, apex_pci_fixup_class);
++
++#define PCI_DEVICE_ID_LEABA_PACIFIC    0xabcd
++#define PCI_DEVICE_ID_LEABA_GIBRALTAR  0xa001
++#define PCI_DEVICE_ID_LEABA_GRAPHENE   0xa003
++#define PCI_DEVICE_ID_LEABA_PALLADIUM  0xa004
++#define PCI_DEVICE_ID_LEABA_ARGON      0xa005
++#define PCI_DEVICE_ID_LEABA_KRYPTON    0xa006
++
++/*
++ * For Pacific A0, only BAR 0 is valid
++ */
++static void silicon_one_fixup(struct pci_dev *dev)
++{
++	int i;
++	struct resource *r;
++
++	for (i = 1; i <= PCI_ROM_RESOURCE; i++) {
++		r = &dev->resource[i];
++		if (!r->start && !r->end && !r->flags)
++			continue;
++
++		pci_info(dev, "Cisco Silicon One BAR %d %pR fixed up\n", i, r);
++		r->start = 0;
++		r->end = 0;
++		r->flags = 0;
++	}
++
++	dev->class = PCI_CLASS_MEMORY_OTHER << 8;
++	pci_info(dev, "Cisco Silicon One class adjusted\n");
++}
++DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_SYNOPSYS, PCI_DEVICE_ID_LEABA_PACIFIC,
++				silicon_one_fixup);
++DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_CISCO, PCI_DEVICE_ID_LEABA_PACIFIC,
++				silicon_one_fixup);
++DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_CISCO, PCI_DEVICE_ID_LEABA_GIBRALTAR,
++				silicon_one_fixup);
++DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_CISCO, PCI_DEVICE_ID_LEABA_GRAPHENE,
++				silicon_one_fixup);
++DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_CISCO, PCI_DEVICE_ID_LEABA_PALLADIUM,
++				silicon_one_fixup);
++DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_CISCO, PCI_DEVICE_ID_LEABA_ARGON,
++				silicon_one_fixup);
++DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_CISCO, PCI_DEVICE_ID_LEABA_KRYPTON,
++				silicon_one_fixup);
++
+-- 
+2.26.2.dirty
+

--- a/patch/cisco-x86-gpio-config.patch
+++ b/patch/cisco-x86-gpio-config.patch
@@ -1,0 +1,42 @@
+From 7106f3961be1dc0d921efe5c719ada6096307227 Mon Sep 17 00:00:00 2001
+From: Madhava Reddy Siddareddygari <msiddare@cisco.com>
+Date: Tue, 10 Aug 2021 12:51:47 -0700
+Subject: [PATCH] x86/Kconfig: Introduce ARCH_NR_GPIO
+
+The x86 platform did not allow configuring the maximum number of GPIOs
+supported, although the ARM platform did. For cisco-8000 platform,
+each FPGA gpio IP block can support 1K pins. Distributed chassis with
+Route Processor and Fabric cards can have 10 such IP blocks, along with
+additional pins through i2c gpio extenders.
+
+This patch supports configurable number of GPIO's at kernel config time
+similar to ARM platform.
+
+Signed-off-by: Madhava Reddy Siddareddygari <msiddare@cisco.com>
+---
+ arch/x86/Kconfig | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/arch/x86/Kconfig b/arch/x86/Kconfig
+index d2453b251..e894cd71d 100644
+--- a/arch/x86/Kconfig
++++ b/arch/x86/Kconfig
+@@ -1033,6 +1033,15 @@ config SCHED_MC_PRIO
+ 
+ 	  If unsure say Y here.
+ 
++config ARCH_NR_GPIO
++	int
++	prompt "Maximum number of GPIO's"
++	default 512
++	help
++	  Maximum number of GPIOs in the system.
++
++	  If unsure, leave the default value.
++
+ config UP_LATE_INIT
+        def_bool y
+        depends on !SMP && X86_LOCAL_APIC
+-- 
+2.26.2
+

--- a/patch/series
+++ b/patch/series
@@ -91,6 +91,7 @@ cisco-Enable-static-memory-reservation-for-OIRable-PCIe-de.patch
 cisco-add-support-for-ltc2979-chip.patch
 cisco-acpi-spi-nor.patch
 cisco-x86-gpio-config.patch
+cisco-npu-disable-other-bars.patch
 
 #
 # Marvell platform patches for 4.19

--- a/patch/series
+++ b/patch/series
@@ -82,6 +82,9 @@ net-sch_generic-fix-the-missing-new-qdisc-assignment.patch
 0031-backport-nvme-Add-hardware-monitoring-support.patch
 0032-platform-mellanox-mlxreg-hotplug-Use-capability-regi.patch
 
+# Cisco patches for 4.19 kernel
+cisco-ds4424-null-of-node.patch
+
 #
 # Marvell platform patches for 4.19
 armhf_secondary_boot_online.patch

--- a/patch/series
+++ b/patch/series
@@ -87,6 +87,7 @@ cisco-ds4424-null-of-node.patch
 cisco-hwmon-pmbus_core-pec-support-check.patch
 cisco-mdio-mux-support-acpi.patch
 cisco-mtd-part.patch
+cisco-Enable-static-memory-reservation-for-OIRable-PCIe-de.patch
 
 #
 # Marvell platform patches for 4.19

--- a/patch/series
+++ b/patch/series
@@ -84,6 +84,7 @@ net-sch_generic-fix-the-missing-new-qdisc-assignment.patch
 
 # Cisco patches for 4.19 kernel
 cisco-ds4424-null-of-node.patch
+cisco-hwmon-pmbus_core-pec-support-check.patch
 
 #
 # Marvell platform patches for 4.19

--- a/patch/series
+++ b/patch/series
@@ -90,6 +90,7 @@ cisco-mtd-part.patch
 cisco-Enable-static-memory-reservation-for-OIRable-PCIe-de.patch
 cisco-add-support-for-ltc2979-chip.patch
 cisco-acpi-spi-nor.patch
+cisco-x86-gpio-config.patch
 
 #
 # Marvell platform patches for 4.19

--- a/patch/series
+++ b/patch/series
@@ -86,6 +86,7 @@ net-sch_generic-fix-the-missing-new-qdisc-assignment.patch
 cisco-ds4424-null-of-node.patch
 cisco-hwmon-pmbus_core-pec-support-check.patch
 cisco-mdio-mux-support-acpi.patch
+cisco-mtd-part.patch
 
 #
 # Marvell platform patches for 4.19

--- a/patch/series
+++ b/patch/series
@@ -89,6 +89,7 @@ cisco-mdio-mux-support-acpi.patch
 cisco-mtd-part.patch
 cisco-Enable-static-memory-reservation-for-OIRable-PCIe-de.patch
 cisco-add-support-for-ltc2979-chip.patch
+cisco-acpi-spi-nor.patch
 
 #
 # Marvell platform patches for 4.19

--- a/patch/series
+++ b/patch/series
@@ -88,6 +88,7 @@ cisco-hwmon-pmbus_core-pec-support-check.patch
 cisco-mdio-mux-support-acpi.patch
 cisco-mtd-part.patch
 cisco-Enable-static-memory-reservation-for-OIRable-PCIe-de.patch
+cisco-add-support-for-ltc2979-chip.patch
 
 #
 # Marvell platform patches for 4.19

--- a/patch/series
+++ b/patch/series
@@ -85,6 +85,7 @@ net-sch_generic-fix-the-missing-new-qdisc-assignment.patch
 # Cisco patches for 4.19 kernel
 cisco-ds4424-null-of-node.patch
 cisco-hwmon-pmbus_core-pec-support-check.patch
+cisco-mdio-mux-support-acpi.patch
 
 #
 # Marvell platform patches for 4.19


### PR DESCRIPTION
Cisco Kernel Patches to support 4.19.x kernel.

Following are the list of patches combined into a single PR as per the suggestion from MSFT

cisco-Enable-static-memory-reservation-for-OIRable-PCIe-de.patch
cisco-acpi-spi-nor.patch
cisco-add-support-for-ltc2979-chip.patch
cisco-ds4424-null-of-node.patch
cisco-hwmon-pmbus_core-pec-support-check.patch
cisco-mdio-mux-support-acpi.patch
cisco-mtd-part.patch
cisco-npu-disable-other-bars.patch
cisco-x86-gpio-config.patch

These patches are already reviewed and submitted to azure/sonic-linux-kernel master branch. Current PR is to backport the patches to 202012 branch.

Detailed description of functionality is provided in these patches.
