### PR TITLE
[201811] Apply kernel patches to fix emmc unreliability

### DIFF
--- a/patch/driver-arista-mmc-drive-strength.patch
+++ b/patch/driver-arista-mmc-drive-strength.patch
@@ -1,0 +1,78 @@
+mmc: add drive strength parameter for eMMC
+
+The original version of this patch (for kernel 3.18) added drive
+strength support for HS200. The drive strength value was specified
+through the mmc_drive_strength mmc module parameter and applied directly
+to setting EXT_CSD_HS_TIMING in mmc_select_hs200().
+
+Upstream commit cc4f414c885cd04f7227ad9bcd6b18fd78d718d9 (included in
+kernel 4.2) adds drive strength support to setting EXT_CSD_HS_TIMING (in
+drivers/mmc/core/mmc.c). This is done for both HS200 and HS400 and uses
+the drive_strength value in struct mmc_card. In the case of the PCI
+SDHCI driver and HS200 mode, this value is initialized in the following
+call stack:
+
+sdhci_pci_select_drive_strength   drivers/mmc/host/sdhci-pci-core.c
+sdhci_select_drive_strength       drivers/mmc/host/sdhci.c
+mmc_select_driver_type            drivers/mmc/core/mmc.c
+mmc_select_hs200                  drivers/mmc/core/mmc.c
+mmc_select_timing                 drivers/mmc/core/mmc.c
+mmc_init_card                     drivers/mmc/core/mmc.c
+mmc_attach_mmc                    drivers/mmc/core/mmc.c
+mmc_rescan_try_freq               drivers/mmc/core/core.c
+mmc_rescan                        drivers/mmc/core/core.c
+^
+'--- called as delayed work ((struct mmc_host).detect -- see mmc_alloc_host())
+
+The current version of this patch achieves similar functionality by
+relying on commit cc4f414c885cd04f7227ad9bcd6b18fd78d718d9 and adding a
+sdhci-pci module parameter. The parameter is called
+default_drive_strength and is used in sdhci_pci_select_drive_strength
+(instead of 0) when slot->select_drive_strength (which is the case for
+almost all PCI devices except Intel SPT eMMC).
+
+TLDR: To set a different drive strength than 0 (50 Ohms) to
+      EXT_CSD_HS_TIMING, use sdhci_pci.default_drive_strength instead of
+      mmc.mmc_drive_strength.
+
+Signed-off-by: edchien@arista.com
+Signed-off-by: Radu Rendec <rrendec@arista.com>
+Signed-off-by: Samuel Angebault <staphylo@arista.com>
+---
+ drivers/mmc/host/sdhci-pci-core.c |   12 +++++++++++-
+ 1 file changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/mmc/host/sdhci-pci-core.c b/drivers/mmc/host/sdhci-pci-core.c
+index cfb79476..d8fff703 100644
+--- a/drivers/mmc/host/sdhci-pci-core.c
++++ b/drivers/mmc/host/sdhci-pci-core.c
+@@ -32,6 +32,14 @@
+ #include "sdhci-pci.h"
+ #include "sdhci-pci-o2micro.h"
+ 
++/*
++ * Set the drive strength for eMMC. The default is 50 ohms. If required,
++ * we could change strength to 33 ohms. Per JEDEC spec section 10.5.4.1:
++ * 0x0 - 50 Ohms, 0x1 - 33 Ohms, 0x2 - 66 Ohms, 0x3 - 100 Ohms
++ */
++int default_drive_strength;
++module_param(default_drive_strength, int, 0444);
++
+ static int sdhci_pci_enable_dma(struct sdhci_host *host);
+ static void sdhci_pci_set_bus_width(struct sdhci_host *host, int width);
+ static void sdhci_pci_hw_reset(struct sdhci_host *host);
+@@ -1459,7 +1467,7 @@ static int sdhci_pci_select_drive_strength(struct sdhci_host *host,
+ 	struct sdhci_pci_slot *slot = sdhci_priv(host);
+ 
+ 	if (!slot->select_drive_strength)
+-		return 0;
++		return default_drive_strength;
+ 
+ 	return slot->select_drive_strength(host, card, max_dtr, host_drv,
+ 					   card_drv, drv_type);
+@@ -1926,3 +1934,5 @@ module_pci_driver(sdhci_driver);
+ MODULE_AUTHOR("Pierre Ossman <pierre@ossman.eu>");
+ MODULE_DESCRIPTION("Secure Digital Host Controller Interface PCI driver");
+ MODULE_LICENSE("GPL");
++
++MODULE_PARM_DESC(default_drive_strength, "Default eMMC drive strength");

--- a/patch/driver-arista-mmc-not-working-on-AMD-platforms.patch
+++ b/patch/driver-arista-mmc-not-working-on-AMD-platforms.patch
@@ -1,0 +1,32 @@
+amd/mmc: kernel-4.9: mmcblk not working on AMD platforms
+
+ADMA and ADMA-64 seem to be broken on AMD. This patch enables the
+following quirks (for AMD only):
+    SDHCI_QUIRK_BROKEN_ADMA
+    SDHCI_QUIRK2_BROKEN_64_BIT_DMA
+
+Signed-off-by: Radu Rendec <rrendec@arista.com>
+Signed-off-by: Samuel Angebault <staphylo@arista.com>
+---
+ drivers/mmc/host/sdhci-pci-core.c |    7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/mmc/host/sdhci-pci-core.c b/drivers/mmc/host/sdhci-pci-core.c
+index cc7907e2..ea5ce470 100644
+--- a/drivers/mmc/host/sdhci-pci-core.c
++++ b/drivers/mmc/host/sdhci-pci-core.c
+@@ -933,8 +933,13 @@ static int amd_probe(struct sdhci_pci_chip *chip)
+ 		}
+ 	}
+ 
+-	if (gen == AMD_CHIPSET_BEFORE_ML || gen == AMD_CHIPSET_CZ)
++	dev_info(&chip->pdev->dev, "identified AMD generation %d chip\n", gen);
++
++	if (gen == AMD_CHIPSET_BEFORE_ML || gen == AMD_CHIPSET_CZ) {
++		chip->quirks |= SDHCI_QUIRK_BROKEN_ADMA;
++		chip->quirks2 |= SDHCI_QUIRK2_BROKEN_64_BIT_DMA;
+ 		chip->quirks2 |= SDHCI_QUIRK2_CLEAR_TRANSFERMODE_REG_BEFORE_CMD;
++	}
+ 
+ 	return 0;
+ }

--- a/patch/driver-arista-mmc-restrict-eMMC-drive-to-50Mhz-from-cmdline.patch
+++ b/patch/driver-arista-mmc-restrict-eMMC-drive-to-50Mhz-from-cmdline.patch
@@ -1,0 +1,70 @@
+mmc: restrict eMMC drive to 50Mhz from cmdline
+
+This issue was fixed for kernel 3.18 by setting sdhci.debug_quirks2=0x40
+from on the cmdline (conditionally, for specific Aboot versions).
+
+For kernel 4.9, however, we need SDHCI_QUIRK2_BROKEN_64_BIT_DMA, which
+is also in quirks2. The problem is that debug_quirks2 overwrites whatever
+is written to host->quirks2 during device probing (see __sdhci_read_caps).
+Since we set both SDHCI_QUIRK_BROKEN_DMA and
+SDHCI_QUIRK2_BROKEN_64_BIT_DMA (but the former is in quirks while the
+latter is in quirks2) and Aboot overwrites quirks2, we end up with only
+SDHCI_QUIRK_BROKEN_DMA being set. This causes some strange behavior with
+AMD devices, where the sdhci driver stalls for a while and eventually
+falls back to PIO mode. We need both quirk flags to be set in order for
+the controller to work in SDMA mode.
+
+This patch is a workaround for the quirks2 overwrite problem. It adds a
+set of new sdhci module parameters (append_quirks and append_quirks2)
+that *append* bits (i.e. logical "or") instead of overwriting the
+values. Then Aboot can use these parameters instead in order to set
+SDHCI_QUIRK2_BROKEN_HS200. Note that both quirk2 flags are set
+conditionally and independently by Aboot and the sdhci-pci probe code.
+
+Advantages of this approach:
+* This patch by itself doesn't change any kernel behavior: it just adds
+  two module parameters that default to zero and will have no effect
+  unless explicitly set to a different value from outside the driver.
+* SDHCI_QUIRK2_BROKEN_HS200 can be still controlled from Aboot and
+  conditionally (depending on the Aboot version).
+* SDHCI_QUIRK2_BROKEN_64_BIT_DMA can be set by the sdhci-pci probing
+  code, independently of Aboot.
+
+Signed-off-by: Radu Rendec <rrendec@arista.com>
+Signed-off-by: Samuel Angebault <staphylo@arista.com>
+---
+ drivers/mmc/host/sdhci.c |    7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/drivers/mmc/host/sdhci.c b/drivers/mmc/host/sdhci.c
+index 44ea9d88..42f5528a 100644
+--- a/drivers/mmc/host/sdhci.c
++++ b/drivers/mmc/host/sdhci.c
+@@ -40,6 +40,8 @@
+ 
+ #define MAX_TUNING_LOOP 40
+ 
++static unsigned int append_quirks;
++static unsigned int append_quirks2;
+ static unsigned int debug_quirks = 0;
+ static unsigned int debug_quirks2;
+ 
+@@ -3048,6 +3050,9 @@ void __sdhci_read_caps(struct sdhci_host *host, u16 *ver, u32 *caps, u32 *caps1)
+ 
+ 	host->read_caps = true;
+ 
++	host->quirks |= append_quirks;
++	host->quirks2 |= append_quirks2;
++
+ 	if (debug_quirks)
+ 		host->quirks = debug_quirks;
+ 
+@@ -3738,6 +3743,8 @@ static void __exit sdhci_drv_exit(void)
+ module_init(sdhci_drv_init);
+ module_exit(sdhci_drv_exit);
+ 
++module_param(append_quirks, uint, 0444);
++module_param(append_quirks2, uint, 0444);
+ module_param(debug_quirks, uint, 0444);
+ module_param(debug_quirks2, uint, 0444);
+ 

--- a/patch/linux-4.11-mmc-sdhci-pci-Add-support-for-HS200-tuning-mode-on-AMD.patch
+++ b/patch/linux-4.11-mmc-sdhci-pci-Add-support-for-HS200-tuning-mode-on-AMD.patch
@@ -1,0 +1,146 @@
+amd/mmc: 3.18 kernel not enabling HS200 mode for SteppeEagle systems
+
+Backport HS200 tuning patch from kernel 4.11.
+
+The upstream patch applied cleanly, with only line offset changes.
+
+Signed-off-by: Radu Rendec <rrendec@arista.com>
+Signed-off-by: Samuel Angebault <staphylo@arista.com>
+
+From c31165d7400bb1ec12291170c9c4d072d5b0ba45 Mon Sep 17 00:00:00 2001
+From: Shyam Sundar S K <ssundark@amd.com>
+Date: Thu, 12 Jan 2017 18:09:00 +0530
+Subject: [PATCH] mmc: sdhci-pci: Add support for HS200 tuning mode on AMD,
+ eMMC-4.5.1
+
+This patch adds support for HS200 tuning mode on AMD eMMC-4.5.1
+
+Reviewed-by: Sen, Pankaj <Pankaj.Sen@amd.com>
+Reviewed-by: Shah, Nehal-bakulchandra <Nehal-bakulchandra.Shah@amd.com>
+Reviewed-by: Agrawal, Nitesh-kumar <Nitesh-kumar.Agrawal@amd.com>
+Signed-off-by: S-k, Shyam-sundar <Shyam-sundar.S-k@amd.com>
+Acked-by: Adrian Hunter <adrian.hunter@intel.com>
+Signed-off-by: Ulf Hansson <ulf.hansson@linaro.org>
+---
+ drivers/mmc/host/sdhci-pci-core.c |   94 ++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 91 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/mmc/host/sdhci-pci-core.c b/drivers/mmc/host/sdhci-pci-core.c
+index d8fff703..cc7907e2 100644
+--- a/drivers/mmc/host/sdhci-pci-core.c
++++ b/drivers/mmc/host/sdhci-pci-core.c
+@@ -831,6 +831,86 @@ enum amd_chipset_gen {
+ 	AMD_CHIPSET_UNKNOWN,
+ };
+ 
++/* AMD registers */
++#define AMD_SD_AUTO_PATTERN		0xB8
++#define AMD_MSLEEP_DURATION		4
++#define AMD_SD_MISC_CONTROL		0xD0
++#define AMD_MAX_TUNE_VALUE		0x0B
++#define AMD_AUTO_TUNE_SEL		0x10800
++#define AMD_FIFO_PTR			0x30
++#define AMD_BIT_MASK			0x1F
++
++static void amd_tuning_reset(struct sdhci_host *host)
++{
++	unsigned int val;
++
++	val = sdhci_readw(host, SDHCI_HOST_CONTROL2);
++	val |= SDHCI_CTRL_PRESET_VAL_ENABLE | SDHCI_CTRL_EXEC_TUNING;
++	sdhci_writew(host, val, SDHCI_HOST_CONTROL2);
++
++	val = sdhci_readw(host, SDHCI_HOST_CONTROL2);
++	val &= ~SDHCI_CTRL_EXEC_TUNING;
++	sdhci_writew(host, val, SDHCI_HOST_CONTROL2);
++}
++
++static void amd_config_tuning_phase(struct pci_dev *pdev, u8 phase)
++{
++	unsigned int val;
++
++	pci_read_config_dword(pdev, AMD_SD_AUTO_PATTERN, &val);
++	val &= ~AMD_BIT_MASK;
++	val |= (AMD_AUTO_TUNE_SEL | (phase << 1));
++	pci_write_config_dword(pdev, AMD_SD_AUTO_PATTERN, val);
++}
++
++static void amd_enable_manual_tuning(struct pci_dev *pdev)
++{
++	unsigned int val;
++
++	pci_read_config_dword(pdev, AMD_SD_MISC_CONTROL, &val);
++	val |= AMD_FIFO_PTR;
++	pci_write_config_dword(pdev, AMD_SD_MISC_CONTROL, val);
++}
++
++static int amd_execute_tuning(struct sdhci_host *host, u32 opcode)
++{
++	struct sdhci_pci_slot *slot = sdhci_priv(host);
++	struct pci_dev *pdev = slot->chip->pdev;
++	u8 valid_win = 0;
++	u8 valid_win_max = 0;
++	u8 valid_win_end = 0;
++	u8 ctrl, tune_around;
++
++	amd_tuning_reset(host);
++
++	for (tune_around = 0; tune_around < 12; tune_around++) {
++		amd_config_tuning_phase(pdev, tune_around);
++
++		if (mmc_send_tuning(host->mmc, opcode, NULL)) {
++			valid_win = 0;
++			msleep(AMD_MSLEEP_DURATION);
++			ctrl = SDHCI_RESET_CMD | SDHCI_RESET_DATA;
++			sdhci_writeb(host, ctrl, SDHCI_SOFTWARE_RESET);
++		} else if (++valid_win > valid_win_max) {
++			valid_win_max = valid_win;
++			valid_win_end = tune_around;
++		}
++	}
++
++	if (!valid_win_max) {
++		dev_err(&pdev->dev, "no tuning point found\n");
++		return -EIO;
++	}
++
++	amd_config_tuning_phase(pdev, valid_win_end - valid_win_max / 2);
++
++	amd_enable_manual_tuning(pdev);
++
++	host->mmc->retune_period = 0;
++
++	return 0;
++}
++
+ static int amd_probe(struct sdhci_pci_chip *chip)
+ {
+ 	struct pci_dev	*smbus_dev;
+@@ -853,16 +933,24 @@ static int amd_probe(struct sdhci_pci_chip *chip)
+ 		}
+ 	}
+ 
+-	if ((gen == AMD_CHIPSET_BEFORE_ML) || (gen == AMD_CHIPSET_CZ)) {
++	if (gen == AMD_CHIPSET_BEFORE_ML || gen == AMD_CHIPSET_CZ)
+ 		chip->quirks2 |= SDHCI_QUIRK2_CLEAR_TRANSFERMODE_REG_BEFORE_CMD;
+-		chip->quirks2 |= SDHCI_QUIRK2_BROKEN_HS200;
+-	}
+ 
+ 	return 0;
+ }
+ 
++static const struct sdhci_ops amd_sdhci_pci_ops = {
++	.set_clock			= sdhci_set_clock,
++	.enable_dma			= sdhci_pci_enable_dma,
++	.set_bus_width			= sdhci_pci_set_bus_width,
++	.reset				= sdhci_reset,
++	.set_uhs_signaling		= sdhci_set_uhs_signaling,
++	.platform_execute_tuning	= amd_execute_tuning,
++};
++
+ static const struct sdhci_pci_fixes sdhci_amd = {
+ 	.probe		= amd_probe,
++	.ops		= &amd_sdhci_pci_ops,
+ };
+ 
+ static const struct pci_device_id pci_ids[] = {

--- a/patch/series
+++ b/patch/series
@@ -15,6 +15,10 @@ driver-arista-net-tg3-dma-mask-4g-sb800.patch
 driver-arista-net-tg3-disallow-broadcom-default-mac.patch
 driver-arista-net-tg3-access-regs-indirectly.patch
 driver-arista-disable-smbus-mux-for-hudson2.patch
+linux-4.11-mmc-sdhci-pci-Add-support-for-HS200-tuning-mode-on-AMD.patch
+driver-arista-mmc-drive-strength.patch
+driver-arista-mmc-not-working-on-AMD-platforms.patch
+driver-arista-mmc-restrict-eMMC-drive-to-50Mhz-from-cmdline.patch
 driver-support-sff-8436-eeprom.patch
 driver-support-sff-8436-eeprom-update.patch
 driver-sff-8436-use-nvmem-framework.patch


### PR DESCRIPTION
Some patches are required to fix some emmc unreliability seen on AMD platforms.
These were ported over from the EOS kernel and applied properly.