### PR TITLE
[201811] Increase log_buf_len size to 1M

### DIFF
--- a/patch/config-log-buf-len-increase.patch
+++ b/patch/config-log-buf-len-increase.patch
@@ -1,0 +1,29 @@
+From fb11280721d0a8f44dc436f730da74382cdd98ab Mon Sep 17 00:00:00 2001
+From: Samuel Angebault <staphylo@arista.com>
+Date: Thu, 10 Feb 2022 15:22:29 +0000
+Subject: Increase default kernel log buffer from 128K to 1M
+
+Though SONiC stores the dmesg in the syslog it create debugging challenges when
+/var/log can't be written to.
+Increasing the dmesg log size will prove useful in such circumpstances.
+
+---
+ debian/build/build_amd64_none_amd64/.config | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/debian/build/build_amd64_none_amd64/.config b/debian/build/build_amd64_none_amd64/.config
+index 6e5997f..0d2d4e9 100644
+--- a/debian/build/build_amd64_none_amd64/.config
++++ b/debian/build/build_amd64_none_amd64/.config
+@@ -142,7 +142,7 @@ CONFIG_RCU_STALL_COMMON=y
+ # CONFIG_RCU_EXPEDITE_BOOT is not set
+ CONFIG_BUILD_BIN2C=y
+ # CONFIG_IKCONFIG is not set
+-CONFIG_LOG_BUF_SHIFT=17
++CONFIG_LOG_BUF_SHIFT=20
+ CONFIG_LOG_CPU_MAX_BUF_SHIFT=12
+ CONFIG_NMI_LOG_BUF_SHIFT=13
+ CONFIG_HAVE_UNSTABLE_SCHED_CLOCK=y
+-- 
+2.11.0
+

--- a/patch/series
+++ b/patch/series
@@ -44,6 +44,7 @@ config-arista-7060-cx32s.patch
 config-mitac-ly1200.patch
 config-optoe.patch
 config-inventec-d7032.patch
+config-log-buf-len-increase.patch
 0014-mlxsw-qsfp_sysfs-Support-CPLD-version-reading-based-.patch
 0015-platform-x86-mlx-platform-Add-support-for-new-msn201.patch
 0016-platform-mellanox-mlxreg-hotplug-add-extra-run-cycle.patch


### PR DESCRIPTION
This increase allows for more logs to be stored in the kernel log buffer.
The default was 128k which this config change bumps to 1M.
It can prove useful in cases where /var/log becomes un-writtable.