### PR TITLE
Re-add certain parts of cisco-x86-gpio-config.patch

### DIFF
--- a/patch/cisco-x86-gpio-config.patch
+++ b/patch/cisco-x86-gpio-config.patch
@@ -1,0 +1,40 @@
+From 7106f3961be1dc0d921efe5c719ada6096307227 Mon Sep 17 00:00:00 2001
+From: Madhava Reddy Siddareddygari <msiddare@cisco.com>
+Date: Tue, 10 Aug 2021 12:51:47 -0700
+Subject: [PATCH] x86/Kconfig: Introduce ARCH_NR_GPIO
+
+The x86 platform did not allow configuring the maximum number of GPIOs
+supported, although the ARM platform did. For cisco-8000 platform,
+each FPGA gpio IP block can support 1K pins. Distributed chassis with
+Route Processor and Fabric cards can have 10 such IP blocks, along with
+additional pins through i2c gpio extenders.
+
+This patch supports configurable number of GPIO's at kernel config time
+similar to ARM platform.
+
+Signed-off-by: Madhava Reddy Siddareddygari <msiddare@cisco.com>
+---
+ arch/x86/Kconfig | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/arch/x86/Kconfig b/arch/x86/Kconfig
+index d2453b251..e894cd71d 100644
+--- a/arch/x86/Kconfig
++++ b/arch/x86/Kconfig
+@@ -342,6 +342,11 @@ config SCHED_MC_PRIO
+ 
+ config ARCH_NR_GPIO
+ 	int
++	prompt "Maximum number of GPIO's"
+ 	default 1024 if X86_64
+ 	default 512
++	help
++	  Maximum number of GPIOs in the system.
++
++	  If unsure, leave the default value.
+ 
+ config ARCH_SUSPEND_POSSIBLE
+ 	def_bool y
+-- 
+2.26.2
+

--- a/patch/series
+++ b/patch/series
@@ -138,6 +138,7 @@ kernel-compat-always-include-linux-compat.h-from-net-compat.patch
 # Cisco patches for 5.10 kernel
 cisco-mtd-part.patch
 cisco-mdio-mux-support-acpi.patch
+cisco-x86-gpio-config.patch
 cisco-acpi-spi-nor.patch
 cisco-Enable-static-memory-reservation-for-OIRable-PCIe-de.patch
 cisco-npu-disable-other-bars.patch


### PR DESCRIPTION
In the 202012 branch, there is a config option committed to set the
number of GPIOs on the system to 10240, because some Cisco hardware
could have that many GPIOs. This config option is, for whatever reason,
not on the master branch.

Therefore, re-add cisco-x86-gpio-config.patch, but reduce it to the
parts that allow configuration of the config.

Signed-off-by: Saikrishna Arcot <sarcot@microsoft.com>