### PR TITLE
[202012] Increase log_buf_len to 1M for all architecture

### DIFF
--- a/patch/kconfig-inclusions
+++ b/patch/kconfig-inclusions
@@ -1,4 +1,5 @@
 [common]
+CONFIG_LOG_BUF_SHIFT=20
 
 [amd64]
 # For Arista


### PR DESCRIPTION
This increase allows for more logs to be stored in the kernel log buffer.
The default was 128k which this config change bumps to 1M.
It can prove useful in cases where /var/log becomes un-writtable.