### PR TITLE
[patch] mlxsw: i2c: Prevent transaction execution for special chip

### DIFF
--- a/patch/0098-mlxsw-i2c-Prevent-transaction-execution-for.patch
+++ b/patch/0098-mlxsw-i2c-Prevent-transaction-execution-for.patch
@@ -1,7 +1,7 @@
 From d3e0bf403d527f717a62ea328781256f999d4f95 Mon Sep 17 00:00:00 2001
 From: Stepan Blyschak <stepanb@nvidia.com>
 Date: Mon, 20 Jun 2022 19:28:04 +0300
-Subject: [PATCH] TMP: mlxsw: i2c: Prevent transaction execution for special
+Subject: [PATCH] mlxsw: i2c: Prevent transaction execution for special
  chip states
 
 Do not run transaction in cases chip is in reset or in-service update
@@ -59,12 +59,12 @@ index 939b692ff..3c9d2c7a0 100644
  	u16 block_size;
 +	u8 status;
  };
- 
+
  #define MLXSW_I2C_READ_MSG(_client, _addr_buf, _buf, _len) {	\
 @@ -222,6 +224,19 @@ static int mlxsw_i2c_write_cmd(struct i2c_client *client,
  	return 0;
  }
- 
+
 +static bool
 +mlxsw_i2c_cmd_status_verify(struct device *dev, struct mlxsw_i2c *mlxsw_i2c,
 +			    u8 status)
@@ -82,9 +82,9 @@ index 939b692ff..3c9d2c7a0 100644
  static int
  mlxsw_i2c_write_init_cmd(struct i2c_client *client,
 @@ -405,6 +420,10 @@ mlxsw_i2c_cmd(struct device *dev, u16 opcode, u32 in_mod, size_t in_mbox_size,
- 
+
  	WARN_ON(in_mbox_size % sizeof(u32) || out_mbox_size % sizeof(u32));
- 
+
 +	/* Do not run transaction if chip is in reset or in-service update state. */
 +	if (mlxsw_i2c->status)
 +		return 0;
@@ -93,14 +93,14 @@ index 939b692ff..3c9d2c7a0 100644
  		reg_size = mlxsw_i2c_get_reg_size(in_mbox);
  		num = reg_size / mlxsw_i2c->block_size;
 @@ -479,6 +498,8 @@ mlxsw_i2c_cmd(struct device *dev, u16 opcode, u32 in_mod, size_t in_mbox_size,
- 
+
  cmd_fail:
  	mutex_unlock(&mlxsw_i2c->cmd.lock);
 +	if (mlxsw_i2c_cmd_status_verify(&client->dev, mlxsw_i2c, *status))
 +		err = 0;
  	return err;
  }
- 
+
 @@ -608,14 +629,16 @@ static int mlxsw_i2c_probe(struct i2c_client *client,
  	/* Wait until go bit is cleared. */
  	err = mlxsw_i2c_wait_go_bit(client, mlxsw_i2c, &status);
@@ -110,7 +110,7 @@ index 939b692ff..3c9d2c7a0 100644
 +			dev_err(&client->dev, "HW semaphore is not released");
  		goto errout;
  	}
- 
+
  	/* Validate transaction completion status. */
  	if (status) {
 -		dev_err(&client->dev, "Bad transaction completion status %x\n",
@@ -121,6 +121,6 @@ index 939b692ff..3c9d2c7a0 100644
  		err = -EIO;
  		goto errout;
  	}
--- 
+--
 2.17.1
 

--- a/patch/series
+++ b/patch/series
@@ -128,7 +128,7 @@ kernel-compat-always-include-linux-compat.h-from-net-compat.patch
 0096-hwmon-mlxreg-fan-Modify-PWM-connectivity-valida.patch
 0097-hwmon-mlxreg-fan-Support-distinctive-names-per-.patch
 0999-Revert-mlxsw-thermal-Fix-out-of-bounds-memory-a.patch
-0098-TMP-mlxsw-i2c-Prevent-transaction-execution-for.patch
+0098-mlxsw-i2c-Prevent-transaction-execution-for.patch
 
 
 # Cisco patches for 5.10 kernel


### PR DESCRIPTION
states

Do not run transaction in cases chip is in reset or in-filed update states.

This patch fixes an issue encountered during SONiC warm-reboot: during
ISSU start the kernel reports that CPU stall is detected:

```
INFO: rcu_sched detected stalls on CPUs/tasks
```

This patch won't be upstreamed due to the upstream driver not supporting
ISSU.

Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>