### PR TITLE
Fix slave container used for master branch

### DIFF
--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -42,7 +42,7 @@ jobs:
   timeoutInMinutes: ${{ parameters.timeout }}
 
   container:
-    image: sonicdev-microsoft.azurecr.io:443/${{ parameters.sonic_slave }}:bookworm
+    image: sonicdev-microsoft.azurecr.io:443/${{ parameters.sonic_slave }}:master
 
   steps:
   - checkout: self


### PR DESCRIPTION
Use the master branch tag instead of the bookworm branch tag to get the slave container.