### PR TITLE
Fintek F81214E driver support

### DIFF
--- a/patches-sonic/driver-tty-serial-8250-add-support-for-fintek-F81214E.patch
+++ b/patches-sonic/driver-tty-serial-8250-add-support-for-fintek-F81214E.patch
@@ -1,0 +1,92 @@
+From c8f3ac729f827b655e0a239a3967b47c9dfce606 Mon Sep 17 00:00:00 2001
+From: Ravi Rama <ravindra@nexthop.ai>
+Date: Fri, 13 Mar 2026 14:47:27 -0500
+Subject: [PATCH] serial: 8250_fintek: Add support for F81214E
+
+The F81214E is a LPC/eSPI to 2 UART Super I/O chip.
+
+Functionally, it is the same as the F81216E. The only difference
+is that the F81216E has 4 UART ports, whereas the F81214E has 2
+UART ports.
+
+Signed-off-by: Ravi Rama <ravi.rama@nexthop.ai>
+---
+ drivers/tty/serial/8250/8250_fintek.c | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/tty/serial/8250/8250_fintek.c b/drivers/tty/serial/8250/8250_fintek.c
+index b4461a89b8d0..976c5748905c 100644
+--- a/drivers/tty/serial/8250/8250_fintek.c
++++ b/drivers/tty/serial/8250/8250_fintek.c
+@@ -1,6 +1,6 @@
+ // SPDX-License-Identifier: GPL-2.0
+ /*
+- *  Probe for F81216A LPC to 4 UART
++ *  Probe for F81216A LPC to 4 UART and F81214E LPC/eSPI to 2 UART
+  *
+  *  Copyright (C) 2014-2016 Ricardo Ribalda, Qtechnology A/S
+  */
+@@ -23,6 +23,7 @@
+ #define CHIP_ID_F81216AD 0x1602
+ #define CHIP_ID_F81216E 0x1617
+ #define CHIP_ID_F81216H 0x0501
++#define CHIP_ID_F81214E 0x1417
+ #define CHIP_ID_F81216 0x0802
+ #define VENDOR_ID1 0x23
+ #define VENDOR_ID1_VAL 0x19
+@@ -161,6 +162,7 @@ static int fintek_8250_check_id(struct fintek_8250 *pdata)
+ 	case CHIP_ID_F81216AD:
+ 	case CHIP_ID_F81216E:
+ 	case CHIP_ID_F81216H:
++	case CHIP_ID_F81214E:
+ 	case CHIP_ID_F81216:
+ 		break;
+ 	default:
+@@ -185,6 +187,7 @@ static int fintek_8250_get_ldn_range(struct fintek_8250 *pdata, int *min,
+ 	case CHIP_ID_F81216AD:
+ 	case CHIP_ID_F81216E:
+ 	case CHIP_ID_F81216H:
++	case CHIP_ID_F81214E:
+ 	case CHIP_ID_F81216:
+ 		*min = F81216_LDN_LOW;
+ 		*max = F81216_LDN_HIGH;
+@@ -255,6 +258,7 @@ static void fintek_8250_set_irq_mode(struct fintek_8250 *pdata, bool is_level)
+ 	case CHIP_ID_F81216AD:
+ 	case CHIP_ID_F81216E:
+ 	case CHIP_ID_F81216H:
++	case CHIP_ID_F81214E:
+ 	case CHIP_ID_F81216:
+ 		sio_write_mask_reg(pdata, FINTEK_IRQ_MODE, IRQ_SHARE,
+ 				   IRQ_SHARE);
+@@ -269,6 +273,7 @@ static void fintek_8250_set_max_fifo(struct fintek_8250 *pdata)
+ 	switch (pdata->pid) {
+ 	case CHIP_ID_F81216E: /* 128Bytes FIFO */
+ 	case CHIP_ID_F81216H:
++	case CHIP_ID_F81214E:
+ 	case CHIP_ID_F81966:
+ 	case CHIP_ID_F81866:
+ 		sio_write_mask_reg(pdata, FIFO_CTRL,
+@@ -304,6 +309,7 @@ static void fintek_8250_set_termios(struct uart_port *port,
+ 	switch (pdata->pid) {
+ 	case CHIP_ID_F81216E:
+ 	case CHIP_ID_F81216H:
++	case CHIP_ID_F81214E:
+ 		reg = RS485;
+ 		break;
+ 	case CHIP_ID_F81966:
+@@ -354,6 +360,7 @@ static void fintek_8250_set_termios_handler(struct uart_8250_port *uart)
+ 	switch (pdata->pid) {
+ 	case CHIP_ID_F81216E:
+ 	case CHIP_ID_F81216H:
++	case CHIP_ID_F81214E:
+ 	case CHIP_ID_F81966:
+ 	case CHIP_ID_F81866:
+ 		uart->port.set_termios = fintek_8250_set_termios;
+@@ -446,6 +453,7 @@ static void fintek_8250_set_rs485_handler(struct uart_8250_port *uart)
+ 		break;
+ 
+ 	case CHIP_ID_F81216E: /* F81216E does not support RS485 delays */
++	case CHIP_ID_F81214E: /* F81214E does not support RS485 delays */
+ 		uart->port.rs485_config = fintek_8250_rs485_config;
+ 		uart->port.rs485_supported = fintek_8250_rs485_supported;
+ 		break;

--- a/patches-sonic/series
+++ b/patches-sonic/series
@@ -208,7 +208,7 @@ cisco-npu-disable-other-bars.patch
 0003-xilinx-spi-make-interrupt-optional.patch
 0004-xilinx-spi-platform_get_irq_optional.patch
 0005-xilinx-spi-use-device-property.patch
-
+driver-tty-serial-8250-add-support-for-fintek-F81214E.patch # Linux upstream pending 
 
 # Fix to avoid kernel panic on Kernel 6.1.94
 # https://github.com/sonic-net/sonic-buildimage/issues/20901


### PR DESCRIPTION
Driver support for [Finetk F81214E ](https://www.fintek.com.tw/index.php/en-us/product/prod-bg/bg-uart/uart-espi/f81214e) an LPC/eSPI to 2 UART Super I/O chip. Upstream linux commit to `tty-next` [branch](https://git.kernel.org/pub/scm/linux/kernel/git/gregkh/tty.git/commit/drivers/tty/serial/8250/8250_fintek.c?h=tty-next&id=c8f3ac729f827b655e0a239a3967b47c9dfce606) - will remove this patch if and when this ultimately gets accepted and backported to 6.12.