### PR TITLE
Add nvidia_aspeed_bmc marker

### DIFF
--- a/config.local/arm64/config.sonic-aspeed
+++ b/config.local/arm64/config.sonic-aspeed
@@ -105,3 +105,6 @@ CONFIG_CRYPTO_DEV_ASPEED=y
 # CONFIG_CRYPTO_DEV_ASPEED_RSSS is not set
 # CONFIG_CRYPTO_DEV_ASPEED_ECDSA is not set
 
+###-> nvidia_aspeed_bmc-start
+###-> nvidia_aspeed_bmc-end
+

--- a/patches-sonic/series
+++ b/patches-sonic/series
@@ -235,6 +235,9 @@ nexthop-b27-dts.patch
 0001-Add-device-tree-for-Nokia-BMC-H6-128-platform.patch
 ###-> aspeed-end
 
+###-> nvidia_aspeed_bmc-start
+###-> nvidia_aspeed_bmc-end
+
 # QID-45097: Crackarmor fixes
 qsa-2026-apparmor/0001-apparmor-validate-DFA-start-states-are-in-bounds-in-.patch
 qsa-2026-apparmor/0002-apparmor-fix-memory-leak-in-verify_header.patch


### PR DESCRIPTION
### Summary

Adds an empty `nvidia_aspeed_bmc` marker block to:
- `patches-sonic/series`
- `config.local/arm64/config.sonic-aspeed`

The block is the insertion point that the NVIDIA/Mellanox hw-mgmt integration scripts use to manage BMC-only kernel patches and Kconfig fragments for ASPEED BMCs (AST2700, etc.) separately from the existing `mellanox_hw_mgmt` block.

### Merge ordering

This PR needs to be merged before [sonic-buildimage PR #27038](https://github.com/sonic-net/sonic-buildimage/pull/27038).
PR #27038 ships the BMC-aware hw-mgmt integration script, which aborts with a `FATAL` error if the `nvidia_aspeed_bmc` markers are not already present in `patches-sonic/series`. Merging #27038 first would break sonic-buildimage builds that pick up the new submodule pointer.

### Why this is needed

The dependent change lives in [sonic-buildimage PR #27038](https://github.com/sonic-net/sonic-buildimage/pull/27038)
("Add ASPEED BMC support to hw-mgmt integration scripts"). That PR teaches `platform/mellanox/integrationㄦscripts/hwmgmt_kernel_patches.py` to:
1. Locate the `nvidia_aspeed_bmc` markers in `patches-sonic/series` (`find_bmc_markers` / `find_marker_indices`).
2. Rebuild the BMC patch block on every integration run (`write_bmc_series_block`), removing stale entries with `rm_old_bmc_patches`.
3. Apply BMC Kconfig fragments to `config.local/arm64/config.sonic-aspeed` between the same markers.

The actual BMC patches and Kconfig fragments are produced by the upstream NVIDIA/Mellanox hw-mgmt repository:
[Mellanox/hw-mgmt](https://github.com/Mellanox/hw-mgmt). The integration script in sonic-buildimage consumes a hw-mgmt release tarball, splits out the BMC-only content, and drops it between the markers added by this PR.

If the markers are missing the integration script aborts with:
```
-> FATAL: nvidia_aspeed_bmc markers not found in patches-sonic/series.
   Please update sonic-linux-kernel to include the markers.
```

So the markers must be present in sonic-linux-kernel before the sonic-buildimage submodule pointer can be bumped to a revision that runs the BMC-aware integration script.