### PR TITLE
[kconfig]: Set THP default to madvise instead of always

### DIFF
--- a/config.local/featureset-sonic/config
+++ b/config.local/featureset-sonic/config
@@ -17,3 +17,6 @@ CONFIG_MEDIA_ATTACH=n
 CONFIG_MODULE_COMPRESS=n
 # Disable strict /dev/mem access checks to allow mmap on PCI resource file
 CONFIG_IO_STRICT_DEVMEM=n
+
+# Set THP default to madvise instead of always
+CONFIG_TRANSPARENT_HUGEPAGE_MADVISE=y


### PR DESCRIPTION
**What I did**

Set the kernel compile-time default for Transparent Huge Pages (THP) from always to madvise by adding CONFIG_TRANSPARENT_HUGEPAGE_MADVISE=y in `config.local/featureset-sonic/config`

**Why I did it**

With CONFIG_TRANSPARENT_HUGEPAGE_ALWAYS=y, khugepaged continuously promotes 4KB pages to 2MB huge pages in the background. On memory-constrained network switches this has several negative effects:

- Memory fragmentation: Once promoted, huge pages cannot be partially reclaimed. Even when applications free most of their memory, scattered live objects pin entire 2MB pages, preventing the kernel from reclaiming unused memory.
- Allocator inefficiency: Userspace allocators (e.g., jemalloc) use MADV_DONTNEED to return memory to the kernel, but this is ineffective on sub-ranges of huge pages, causing a persistent gap between application-level and kernel-level memory accounting.
- Process exit latency: Tearing down large THP-backed address spaces under memory pressure can cause threads to block in do_exit(), triggering hung task watchdog timeouts.

Setting the default to madvise ensures THP is only used when applications explicitly opt in via madvise(MADV_HUGEPAGE). This is the recommended setting for latency-sensitive and embedded networking workloads (consistent with guidance by other linux distributions for similar environments).

**How I verified it**

- Built the kernel with updated kconfig and booted on a SONiC switch
- Confirmed: cat /sys/kernel/mm/transparent_hugepage/enabled is set as follows:
        `always [madvise] never`

**Details if related**