### PR TITLE
Add support for the Cadence SD6 SDHCI controller

### DIFF
--- a/patches-sonic/0001-mmc-sdhci-cadence-Add-CN10K-eMMC-support.patch
+++ b/patches-sonic/0001-mmc-sdhci-cadence-Add-CN10K-eMMC-support.patch
@@ -1,0 +1,2883 @@
+From dc877a9ba5783e2e8d2430a2662cf23bb75edddf Mon Sep 17 00:00:00 2001
+From: Renjithkumar Raveendran Nair <renjithkumar@gmail.com>
+Date: Fri, 8 May 2026 00:35:40 +0530
+Subject: [PATCH] mmc: sdhci-cadence: Add CN10K eMMC support
+
+Bring up and harden the Cadence SDHCI driver for Marvell CN10K
+eMMC, including controller-specific timing, ACPI integration,
+and HS400-class operation, along with other fixes.
+
+- Add Cadence SD6 SDHCI controller support for CN10K.
+- Enable HS400 / HS400ES emmc modes;
+- Set host-side PHY delays and default tuning values when DT
+  velues are missing or incorrect.
+- Add ACPI support for the CN10K eMMC SDHCI instance.
+- Implement delay_element handling and Cadence SDHCI tuning
+  logic, including multi-block read/tuning helpers
+- Refresh default tuning parameters and fix DDR, clock, and
+  strobe corner cases (e.g. enhanced strobe, command delay,
+  block-gap, interrupt handling workarounds)
+- Updates the OTX2_MBOX_VERSION to 0x000b. Extends
+  struct nix_lf_alloc_rsp with hw_rx_tstamp_en to match the mbox
+  structure with applications.
+
+Signed-off-by: Renjithkumar Raveendran Nair <renjithkumar@gmail.com>
+---
+ .../devicetree/bindings/mmc/cdns,sdhci.yaml   |    1 +
+ MAINTAINERS                                   |    1 +
+ drivers/mmc/core/mmc_ops.c                    |   73 +
+ drivers/mmc/host/Kconfig                      |   18 +
+ drivers/mmc/host/sdhci-cadence.c              | 2289 +++++++++++++++--
+ .../net/ethernet/marvell/octeontx2/af/mbox.h  |    3 +-
+ include/linux/mmc/host.h                      |    2 +
+ include/soc/marvell/octeontx/octeontx_smc.h   |  125 +
+ 8 files changed, 2347 insertions(+), 165 deletions(-)
+ create mode 100644 include/soc/marvell/octeontx/octeontx_smc.h
+
+diff --git a/Documentation/devicetree/bindings/mmc/cdns,sdhci.yaml b/Documentation/devicetree/bindings/mmc/cdns,sdhci.yaml
+index 6c40611405a0..25a5f80fa021 100644
+--- a/Documentation/devicetree/bindings/mmc/cdns,sdhci.yaml
++++ b/Documentation/devicetree/bindings/mmc/cdns,sdhci.yaml
+@@ -17,6 +17,7 @@ properties:
+           - microchip,mpfs-sd4hc
+           - socionext,uniphier-sd4hc
+       - const: cdns,sd4hc
++      - const: cdns,sd6hc
+ 
+   reg:
+     minItems: 1
+diff --git a/MAINTAINERS b/MAINTAINERS
+index d0f18fdba068..68d9f14b8b7f 100644
+--- a/MAINTAINERS
++++ b/MAINTAINERS
+@@ -13845,6 +13845,7 @@ MARVELL OCTEON CN10K DPI DRIVER
+ M:	Vamsi Attunuru <vattunuru@marvell.com>
+ S:	Supported
+ F:	drivers/misc/mrvl_cn10k_dpi.c
++F:	include/soc/marvell/octeontx/
+ 
+ MARVELL OCTEON ENDPOINT VIRTIO DATA PATH ACCELERATOR
+ R:	schalla@marvell.com
+diff --git a/drivers/mmc/core/mmc_ops.c b/drivers/mmc/core/mmc_ops.c
+index 3b3adbddf664..88bf6d0ceef7 100644
+--- a/drivers/mmc/core/mmc_ops.c
++++ b/drivers/mmc/core/mmc_ops.c
+@@ -1069,3 +1069,76 @@ int mmc_sanitize(struct mmc_card *card, unsigned int timeout_ms)
+ 	return err;
+ }
+ EXPORT_SYMBOL_GPL(mmc_sanitize);
++
++/**
++ * mmc_read_tuning() - read data blocks from the mmc
++ * @host: mmc host doing the read
++ * @blksz: data block size
++ * @blocks: number of blocks to read
++ *
++ * Read one or more blocks of data from the beginning of the mmc. This is a
++ * low-level helper for tuning operation. It is assumed that CMD23 can be used
++ * for multi-block read if the host supports it.
++ *
++ * Note: Allocate and free a temporary buffer to store the data read. The data
++ * is not available outside of the function, only the status of the read
++ * operation.
++ *
++ * Return: 0 in case of success, otherwise -EIO / -ENOMEM / -E2BIG
++ */
++int mmc_read_tuning(struct mmc_host *host, unsigned int blksz,
++		    unsigned int blocks)
++{
++	struct mmc_request mrq = {};
++	struct mmc_command sbc = {};
++	struct mmc_command cmd = {};
++	struct mmc_command stop = {};
++	struct mmc_data data = {};
++	struct scatterlist sg;
++	void *buf;
++	unsigned int len;
++
++	if (blocks > 1) {
++		if (mmc_host_cmd23(host)) {
++			mrq.sbc = &sbc;
++			sbc.opcode = MMC_SET_BLOCK_COUNT;
++			sbc.arg = blocks;
++			sbc.flags = MMC_RSP_R1 | MMC_CMD_AC;
++		}
++		cmd.opcode = MMC_READ_MULTIPLE_BLOCK;
++		mrq.stop = &stop;
++		stop.opcode = MMC_STOP_TRANSMISSION;
++		stop.flags = MMC_RSP_SPI_R1 | MMC_RSP_R1 | MMC_CMD_AC;
++	} else {
++		cmd.opcode = MMC_READ_SINGLE_BLOCK;
++	}
++
++	mrq.cmd = &cmd;
++	cmd.flags = MMC_RSP_SPI_R1 | MMC_RSP_R1 | MMC_CMD_ADTC;
++
++	mrq.data = &data;
++	data.flags = MMC_DATA_READ;
++	data.blksz = blksz;
++	data.blocks = blocks;
++	data.blk_addr = 0;
++	data.sg = &sg;
++	data.sg_len = 1;
++	data.timeout_ns = 1000000000;
++
++	if (check_mul_overflow(blksz, blocks, &len))
++		return -E2BIG;
++	buf = kmalloc(len, GFP_KERNEL);
++	if (!buf)
++		return -ENOMEM;
++
++	sg_init_one(&sg, buf, len);
++
++	mmc_wait_for_req(host, &mrq);
++	kfree(buf);
++
++	if (sbc.error || cmd.error || data.error)
++		return -EIO;
++
++	return 0;
++}
++EXPORT_SYMBOL_GPL(mmc_read_tuning);
+diff --git a/drivers/mmc/host/Kconfig b/drivers/mmc/host/Kconfig
+index 7199cb0bd0b9..4cdf78cc4051 100644
+--- a/drivers/mmc/host/Kconfig
++++ b/drivers/mmc/host/Kconfig
+@@ -276,6 +276,24 @@ config MMC_SDHCI_CADENCE
+ 
+ 	  If unsure, say N.
+ 
++config MMC_SDHCI_CADENCE_DEBUG
++	tristate "Debug support for the Cadence SD/SDIO/eMMC controller"
++	depends on MMC_SDHCI_CADENCE
++	default n
++	help
++	  Say Y here to compile extra diagnostic code into the Cadence
++	  SDHCI driver.  When enabled, the driver can print PHY timing
++	  calculations, delay/DLL settings, and host register snapshots
++	  (HRS/SRS and PHY registers) at key setup points.  This is verbose
++	  and not suitable for production kernels because it adds printk
++	  traffic and may affect real-time behavior.
++
++	  Use this only while bringing up new silicon or debugging eMMC/SD
++	  signal integrity and tuning problems.
++
++	  If you have a controller with this interface, say Y or M here.
++	  If unsure, say N.
++
+ config MMC_SDHCI_ESDHC_MCF
+ 	tristate "SDHCI support for the Freescale eSDHC ColdFire controller"
+ 	depends on M5441x
+diff --git a/drivers/mmc/host/sdhci-cadence.c b/drivers/mmc/host/sdhci-cadence.c
+index be1505e8c536..87022bc6d941 100644
+--- a/drivers/mmc/host/sdhci-cadence.c
++++ b/drivers/mmc/host/sdhci-cadence.c
+@@ -4,8 +4,13 @@
+  *   Author: Masahiro Yamada <yamada.masahiro@socionext.com>
+  */
+ 
++#include <linux/acpi.h>
+ #include <linux/bitfield.h>
+ #include <linux/bits.h>
++#ifdef CONFIG_DMI
++#include <linux/dmi.h>
++#include <linux/unaligned.h>
++#endif
+ #include <linux/iopoll.h>
+ #include <linux/module.h>
+ #include <linux/mmc/host.h>
+@@ -13,33 +18,164 @@
+ #include <linux/of.h>
+ #include <linux/platform_device.h>
+ #include <linux/reset.h>
++#include <linux/string.h>
++#include <linux/of_device.h>
++#include <soc/marvell/octeontx/octeontx_smc.h>
+ 
+ #include "sdhci-pltfm.h"
+ 
+-/* HRS - Host Register Set (specific to Cadence) */
+-#define SDHCI_CDNS_HRS04		0x10		/* PHY access port */
+-#define   SDHCI_CDNS_HRS04_ACK			BIT(26)
+-#define   SDHCI_CDNS_HRS04_RD			BIT(25)
+-#define   SDHCI_CDNS_HRS04_WR			BIT(24)
+-#define   SDHCI_CDNS_HRS04_RDATA		GENMASK(23, 16)
+-#define   SDHCI_CDNS_HRS04_WDATA		GENMASK(15, 8)
+-#define   SDHCI_CDNS_HRS04_ADDR			GENMASK(5, 0)
+-
+-#define SDHCI_CDNS_HRS06		0x18		/* eMMC control */
+-#define   SDHCI_CDNS_HRS06_TUNE_UP		BIT(15)
+-#define   SDHCI_CDNS_HRS06_TUNE			GENMASK(13, 8)
+-#define   SDHCI_CDNS_HRS06_MODE			GENMASK(2, 0)
+-#define   SDHCI_CDNS_HRS06_MODE_SD		0x0
+-#define   SDHCI_CDNS_HRS06_MODE_MMC_SDR		0x2
+-#define   SDHCI_CDNS_HRS06_MODE_MMC_DDR		0x3
+-#define   SDHCI_CDNS_HRS06_MODE_MMC_HS200	0x4
+-#define   SDHCI_CDNS_HRS06_MODE_MMC_HS400	0x5
+-#define   SDHCI_CDNS_HRS06_MODE_MMC_HS400ES	0x6
++#ifdef CONFIG_MMC_SDHCI_CADENCE_DEBUG
++#define DEBUG_DRV(...)	pr_info(__VA_ARGS__)
++#else
++#define DEBUG_DRV(...)
++#endif
++
++#define SDMCLK_MAX_FREQ		200000000
++
++#define DEFAULT_CMD_DELAY		16
++#define SDHCI_CDNS_TUNE_START		16
++#define SDHCI_CDNS_TUNE_STEP		6
++#define SDHCI_CDNS_TUNE_ITERATIONS	40
++#define SDHCI_CDNS_TUNE_MAX_VALUE	256
++#define SDHCI_CDNS_SD6_DEFAULT_DELAY_ELEMENT	8
++#define DEFAULT_READ_DQS_CMD_DELAY	64
++#define DEFAULT_CLK_WRDQS_DELAY		0
++#define DEFAULT_CLK_WR_DELAY		0
++#define DEFAULT_READ_DQS_DELAY		64
++
++#define SDHCI_CDNS_HRS00			0x00
++#define SDHCI_CDNS_HRS00_SWR			BIT(0)
++
++#define SDHCI_CDNS_HRS02			0x08 /* PHY access port */
++#define SDHCI_CDNS_HRS04			0x10 /* PHY access port */
++
++/* SD 4.0 Controller HRS - Host Register Set (specific to Cadence) */
++#define SDHCI_CDNS_SD4_HRS04_ACK		BIT(26)
++#define SDHCI_CDNS_SD4_HRS04_RD			BIT(25)
++#define SDHCI_CDNS_SD4_HRS04_WR			BIT(24)
++#define SDHCI_CDNS_SD4_HRS04_RDATA		GENMASK(23, 16)
++#define SDHCI_CDNS_SD4_HRS04_WDATA		GENMASK(15, 8)
++#define SDHCI_CDNS_SD4_HRS04_ADDR		GENMASK(5, 0)
++
++#define SDHCI_CDNS_HRS06			0x18 /* eMMC control */
++#define SDHCI_CDNS_HRS06_TUNE_UP		BIT(15)
++#define SDHCI_CDNS_HRS06_TUNE			GENMASK(13, 8)
++#define SDHCI_CDNS_HRS06_MODE			GENMASK(2, 0)
++#define SDHCI_CDNS_HRS06_MODE_SD		0x0
++#define SDHCI_CDNS_HRS06_MODE_LEGACY		0x1
++#define SDHCI_CDNS_HRS06_MODE_MMC_SDR		0x2
++#define SDHCI_CDNS_HRS06_MODE_MMC_DDR		0x3
++#define SDHCI_CDNS_HRS06_MODE_MMC_HS200		0x4
++#define SDHCI_CDNS_HRS06_MODE_MMC_HS400		0x5
++#define SDHCI_CDNS_HRS06_MODE_MMC_HS400ES	0x6
++
++/* SD 6.0 Controller HRS - Host Register Set (Specific to Cadence) */
++#define SDHCI_CDNS_SD6_HRS04_ADDR		GENMASK(15, 0)
++
++#define SDHCI_CDNS_HRS05			0x14
++
++#define SDHCI_CDNS_HRS07			0x1C
++#define	SDHCI_CDNS_HRS07_RW_COMPENSATE		GENMASK(20, 16)
++#define	SDHCI_CDNS_HRS07_IDELAY_VAL		GENMASK(4, 0)
++
++#define SDHCI_CDNS_HRS09			0x24
++#define	SDHCI_CDNS_HRS09_RDDATA_EN		BIT(16)
++#define	SDHCI_CDNS_HRS09_RDCMD_EN		BIT(15)
++#define	SDHCI_CDNS_HRS09_EXTENDED_WR_MODE	BIT(3)
++#define	SDHCI_CDNS_HRS09_EXTENDED_RD_MODE	BIT(2)
++#define	SDHCI_CDNS_HRS09_PHY_INIT_COMPLETE	BIT(1)
++#define	SDHCI_CDNS_HRS09_PHY_SW_RESET		BIT(0)
++
++#define SDHCI_CDNS_HRS10			0x28
++#define	SDHCI_CDNS_HRS10_HCSDCLKADJ		GENMASK(19, 16)
++
++#define SDHCI_CDNS_HRS11			0x2c
++/*Reset related*/
++#define SDHCI_CDNS_SRS11_SW_RESET_ALL		BIT(24)
++#define SDHCI_CDNS_SRS11_SW_RESET_CMD		BIT(25)
++#define SDHCI_CDNS_SRS11_SW_RESET_DAT		BIT(26)
++
++#define SDHCI_CDNS_HRS16			0x40
++#define SDHCI_CDNS_HRS16_WRDATA1_SDCLK_DLY	GENMASK(31, 28)
++#define SDHCI_CDNS_HRS16_WRDATA0_SDCLK_DLY	GENMASK(27, 24)
++#define SDHCI_CDNS_HRS16_WRCMD1_SDCLK_DLY	GENMASK(23, 20)
++#define SDHCI_CDNS_HRS16_WRCMD0_SDCLK_DLY	GENMASK(19, 16)
++#define SDHCI_CDNS_HRS16_WRDATA1_DLY		GENMASK(15, 12)
++#define SDHCI_CDNS_HRS16_WRDATA0_DLY		GENMASK(11, 8)
++#define SDHCI_CDNS_HRS16_WRCMD1_DLY		GENMASK(7, 4)
++#define SDHCI_CDNS_HRS16_WRCMD0_DLY		GENMASK(3, 0)
++
++/* PHY registers for SD6 controller */
++#define SDHCI_CDNS_SD6_PHY_DQ_TIMING				0x2000
++#define	SDHCI_CDNS_SD6_PHY_DQ_TIMING_IO_MASK_ALWAYS_ON		BIT(31)
++#define	SDHCI_CDNS_SD6_PHY_DQ_TIMING_IO_MASK_END		GENMASK(29, 27)
++#define	SDHCI_CDNS_SD6_PHY_DQ_TIMING_IO_MASK_START		GENMASK(26, 24)
++#define	SDHCI_CDNS_SD6_PHY_DQ_TIMING_DATA_SELECT_OE_END		GENMASK(2, 0)
++
++#define SDHCI_CDNS_SD6_PHY_DQS_TIMING				0x2004
++#define	SDHCI_CDNS_SD6_PHY_DQS_TIMING_USE_EXT_LPBK_DQS		BIT(22)
++#define	SDHCI_CDNS_SD6_PHY_DQS_TIMING_USE_LPBK_DQS		BIT(21)
++#define	SDHCI_CDNS_SD6_PHY_DQS_TIMING_USE_PHONY_DQS		BIT(20)
++#define	SDHCI_CDNS_SD6_PHY_DQS_TIMING_USE_PHONY_DQS_CMD		BIT(19)
++
++#define SDHCI_CDNS_SD6_PHY_GATE_LPBK				0x2008
++#define	SDHCI_CDNS_SD6_PHY_GATE_LPBK_SYNC_METHOD		BIT(31)
++#define	SDHCI_CDNS_SD6_PHY_GATE_LPBK_SW_HALF_CYCLE_SHIFT	BIT(28)
++#define	SDHCI_CDNS_SD6_PHY_GATE_LPBK_RD_DEL_SEL			GENMASK(24, 19)
++#define	SDHCI_CDNS_SD6_PHY_GATE_LPBK_GATE_CFG_ALWAYS_ON		BIT(6)
++
++#define SDHCI_CDNS_SD6_PHY_DLL_MASTER				0x200C
++#define	SDHCI_CDNS_SD6_PHY_DLL_MASTER_BYPASS_MODE		BIT(23)
++#define	SDHCI_CDNS_SD6_PHY_DLL_MASTER_PHASE_DETECT_SEL		GENMASK(22, 20)
++#define	SDHCI_CDNS_SD6_PHY_DLL_MASTER_DLL_LOCK_NUM		GENMASK(18, 16)
++#define	SDHCI_CDNS_SD6_PHY_DLL_MASTER_DLL_START_POINT		GENMASK(7, 0)
++
++#define SDHCI_CDNS_SD6_PHY_DLL_SLAVE				0x2010
++#define	SDHCI_CDNS_SD6_PHY_DLL_SLAVE_READ_DQS_CMD_DELAY		GENMASK(31, 24)
++#define	SDHCI_CDNS_SD6_PHY_DLL_SLAVE_CLK_WRDQS_DELAY		GENMASK(23, 16)
++#define	SDHCI_CDNS_SD6_PHY_DLL_SLAVE_CLK_WR_DELAY		GENMASK(15, 8)
++#define	SDHCI_CDNS_SD6_PHY_DLL_SLAVE_READ_DQS_DELAY		GENMASK(7, 0)
++
++#define SDHCI_CDNS_SD6_PHY_DLL_OBS_REG0				0x201C
++#define SDHCI_CDNS_SD6_PHY_DLL_OBS_REG0_DLL_LOCK		BIT(0)
++#define SDHCI_CDNS_SD6_PHY_DLL_OBS_REG0_DLL_LOCK_MODE		GENMASK(2, 1)
++#define SDHCI_CDNS_SD6_PHY_DLL_OBS_REG0_DLL_UNLOCK_CNT		GENMASK(7, 3)
++#define SDHCI_CDNS_SD6_PHY_DLL_OBS_REG0_DLL_LOCK_VALUE		GENMASK(15, 8)
++
++#define SDHCI_CDNS_SD6_PHY_DLL_OBS_REG1				0x2020
++#define SDHCI_CDNS_SD6_PHY_DLL_OBS_REG2				0x2024
++
++#define SDHCI_CDNS_SD6_PHY_CTRL					0x2080
++#define	SDHCI_CDNS_SD6_PHY_CTRL_PHONY_DQS_TIMING		GENMASK(9, 4)
++
++#define SDHCI_CDNS_SD6_PHY_GPIO_CTRL0				0x2088
++#define SDHCI_CDNS_SD6_PHY_GPIO_CTRL0_DRV			GENMASK(6, 5)
++#define SDHCI_CDNS_SD6_PHY_GPIO_CTRL0_DRV_OVR_EN		BIT(4)
++#define SDHCI_CDNS_SD6_PHY_GPIO_CTRL0_SLEW			GENMASK(2, 1)
++#define SDHCI_CDNS_SD6_PHY_GPIO_CTRL0_SLEW_OVR_EN		BIT(0)
++
++/* Read block gap */
++#define SDHCI_CDNS_HRS37		0x94	/* interface mode select */
++#define   SDHCI_CDNS_HRS37_MODE_DS		0x0
++#define   SDHCI_CDNS_HRS37_MODE_HS		0x1
++#define   SDHCI_CDNS_HRS37_MODE_UDS_SDR12	0x8
++#define   SDHCI_CDNS_HRS37_MODE_UDS_SDR25	0x9
++#define   SDHCI_CDNS_HRS37_MODE_UDS_SDR50	0xa
++#define   SDHCI_CDNS_HRS37_MODE_UDS_SDR104	0xb
++#define   SDHCI_CDNS_HRS37_MODE_UDS_DDR50	0xc
++#define   SDHCI_CDNS_HRS37_MODE_MMC_LEGACY	0x20
++#define   SDHCI_CDNS_HRS37_MODE_MMC_SDR		0x21
++#define   SDHCI_CDNS_HRS37_MODE_MMC_DDR		0x22
++#define   SDHCI_CDNS_HRS37_MODE_MMC_HS200	0x23
++#define   SDHCI_CDNS_HRS37_MODE_MMC_HS400	0x24
++#define   SDHCI_CDNS_HRS37_MODE_MMC_HS400ES	0x25
++#define SDHCI_CDNS_HRS38		0x98	/* Read block gap coefficient */
++#define   SDHCI_CDNS_HRS38_BLKGAP_MAX		0xf
+ 
+ /* SRS - Slot Register Set (SDHCI-compatible) */
+ #define SDHCI_CDNS_SRS_BASE		0x200
+ 
+-/* PHY */
++/* PHY registers for SD4 controller */
+ #define SDHCI_CDNS_PHY_DLY_SD_HS	0x00
+ #define SDHCI_CDNS_PHY_DLY_SD_DEFAULT	0x01
+ #define SDHCI_CDNS_PHY_DLY_UHS_SDR12	0x02
+@@ -53,6 +189,8 @@
+ #define SDHCI_CDNS_PHY_DLY_HSMMC	0x0c
+ #define SDHCI_CDNS_PHY_DLY_STROBE	0x0d
+ 
++#define CN10K_MSIX_INTR			0x718
++
+ /*
+  * The tuned val register is 6 bit-wide, but not the whole of the range is
+  * available.  The range 0-42 seems to be available (then 43 wraps around to 0)
+@@ -60,11 +198,24 @@
+  */
+ #define SDHCI_CDNS_MAX_TUNING_LOOP	40
+ 
+-struct sdhci_cdns_phy_param {
++static int cn10k_irq_workaround;
++
++static int tune_val_start = SDHCI_CDNS_TUNE_START;
++static int tune_val_step = SDHCI_CDNS_TUNE_STEP;
++static int max_tune_iter = SDHCI_CDNS_TUNE_ITERATIONS;
++
++struct sdhci_cdns_priv;
++
++struct sdhci_cdns_sd4_phy_param {
+ 	u8 addr;
+ 	u8 data;
+ };
+ 
++struct sdhci_cdns_data {
++	int (*phy_init)(struct sdhci_cdns_priv *priv);
++	int (*set_tune_val)(struct sdhci_host *host, unsigned int val);
++};
++
+ struct sdhci_cdns_priv {
+ 	void __iomem *hrs_addr;
+ 	void __iomem *ctl_addr;	/* write control */
+@@ -72,11 +223,13 @@ struct sdhci_cdns_priv {
+ 	bool enhanced_strobe;
+ 	void (*priv_writel)(struct sdhci_cdns_priv *priv, u32 val, void __iomem *reg);
+ 	struct reset_control *rst_hw;
++	const struct sdhci_cdns_data *cdns_data;
++	void *phy;
+ 	unsigned int nr_phy_params;
+-	struct sdhci_cdns_phy_param phy_params[];
++	struct sdhci_cdns_sd4_phy_param phy_params[];
+ };
+ 
+-struct sdhci_cdns_phy_cfg {
++struct sdhci_cdns_sd4_phy_cfg {
+ 	const char *property;
+ 	u8 addr;
+ };
+@@ -84,9 +237,10 @@ struct sdhci_cdns_phy_cfg {
+ struct sdhci_cdns_drv_data {
+ 	int (*init)(struct platform_device *pdev);
+ 	const struct sdhci_pltfm_data pltfm_data;
++	const struct sdhci_cdns_data *cdns_data;
+ };
+ 
+-static const struct sdhci_cdns_phy_cfg sdhci_cdns_phy_cfgs[] = {
++static const struct sdhci_cdns_sd4_phy_cfg sdhci_cdns_sd4_phy_cfgs[] = {
+ 	{ "cdns,phy-input-delay-sd-highspeed", SDHCI_CDNS_PHY_DLY_SD_HS, },
+ 	{ "cdns,phy-input-delay-legacy", SDHCI_CDNS_PHY_DLY_SD_DEFAULT, },
+ 	{ "cdns,phy-input-delay-sd-uhs-sdr12", SDHCI_CDNS_PHY_DLY_UHS_SDR12, },
+@@ -100,125 +254,1724 @@ static const struct sdhci_cdns_phy_cfg sdhci_cdns_phy_cfgs[] = {
+ 	{ "cdns,phy-dll-delay-strobe", SDHCI_CDNS_PHY_DLY_STROBE, },
+ };
+ 
+-static inline void cdns_writel(struct sdhci_cdns_priv *priv, u32 val,
+-			       void __iomem *reg)
+-{
+-	writel(val, reg);
++enum sdhci_cdns_sd6_phy_lock_mode {
++	SDHCI_CDNS_SD6_PHY_LOCK_MODE_FULL_CLK = 0,
++	SDHCI_CDNS_SD6_PHY_LOCK_MODE_HALF_CLK = 2,
++	SDHCI_CDNS_SD6_PHY_LOCK_MODE_SATURATION = 3,
++	SDHCI_CDNS_SD6_PHY_LOCK_MODE_UNITIALIZED = 0xff,
++};
++
++struct sdhci_cdns_sd6_phy_timings {
++	u32 t_cmd_output_min;
++	u32 t_cmd_output_max;
++	u32 t_dat_output_min;
++	u32 t_dat_output_max;
++	u32 t_cmd_input_min;
++	u32 t_cmd_input_max;
++	u32 t_dat_input_min;
++	u32 t_dat_input_max;
++	u32 t_sdclk_min;
++	u32 t_sdclk_max;
++};
++
++struct sdhci_cdns_sd6_phy_delays {
++	u32 phy_sdclk_delay;
++	u32 phy_cmd_o_delay;
++	u32 phy_dat_o_delay;
++	u32 iocell_input_delay;
++	u32 iocell_output_delay;
++	u32 delay_element_org;
++	u32 delay_element;
++};
++
++struct sdhci_cdns_sd6_phy_settings {
++	/* SDHCI_CDNS_SD6_PHY_DLL_SLAVE */
++	u32 cp_read_dqs_cmd_delay;
++	u32 cp_read_dqs_delay;
++	u32 cp_clk_wr_delay;
++	u32 cp_clk_wrdqs_delay;
++
++	/* SDHCI_CDNS_SD6_PHY_DLL_MASTER */
++	u32 cp_dll_bypass_mode;
++	u32 cp_dll_start_point;
++
++	/* SDHCI_CDNS_SD6_PHY_DLL_OBS_REG0 */
++	u32 cp_dll_locked_mode;
++
++	/* SDHCI_CDNS_SD6_PHY_GATE_LPBK */
++	u32 cp_gate_cfg_always_on;
++	u32 cp_sync_method;
++	u32 cp_rd_del_sel;
++	u32 cp_sw_half_cycle_shift;
++	u32 cp_underrun_suppress;
++
++	/* SDHCI_CDNS_SD6_PHY_DQ_TIMING */
++	u32 cp_io_mask_always_on;
++	u32 cp_io_mask_end;
++	u32 cp_io_mask_start;
++	u32 cp_data_select_oe_end;
++
++	/* SDHCI_CDNS_SD6_PHY_DQS_TIMING */
++	u32 cp_use_ext_lpbk_dqs;
++	u32 cp_use_lpbk_dqs;
++	u8 cp_use_phony_dqs;
++	u8 cp_use_phony_dqs_cmd;
++
++	/* HRS 09 */
++	u8 sdhc_extended_rd_mode;
++	u8 sdhc_extended_wr_mode;
++	u32 sdhc_rdcmd_en;
++	u32 sdhc_rddata_en;
++
++	/* HRS10 */
++	u32 sdhc_hcsdclkadj;
++
++	/* HRS 07 */
++	u32 sdhc_idelay_val;
++	u32 sdhc_rw_compensate;
++
++	/* SRS 11 */
++	u32 sdhc_sdcfsh;
++	u32 sdhc_sdcfsl;
++
++	/* HRS 16 */
++	u32 sdhc_wrcmd0_dly;
++	u32 sdhc_wrcmd0_sdclk_dly;
++	u32 sdhc_wrcmd1_dly;
++	u32 sdhc_wrcmd1_sdclk_dly;
++	u32 sdhc_wrdata0_dly;
++	u32 sdhc_wrdata0_sdclk_dly;
++	u32 sdhc_wrdata1_dly;
++	u32 sdhc_wrdata1_sdclk_dly;
++
++	u32 hs200_tune_val;
++	u32 drive;
++	u32 slew;
++};
++
++struct sdhci_cdns_sd6_phy_intermediate_results {
++	u32 t_sdmclk_calc;
++	u32 dll_max_value;
++};
++
++struct sdhci_cdns_sd6_phy {
++	struct sdhci_cdns_sd6_phy_timings t;
++	struct sdhci_cdns_sd6_phy_delays d;
++	u32 t_sdmclk;
++	struct sdhci_cdns_sd6_phy_settings settings;
++	struct sdhci_cdns_sd6_phy_intermediate_results vars;
++	bool ddr;
++	bool tune_cmd;
++	bool tune_dat;
++	bool strobe_cmd;
++	bool strobe_dat;
++	int mode;
++	int t_sdclk;
++};
++
++static int sdhci_cdns_sd6_get_dll_parameters(struct sdhci_cdns_priv *priv,
++					     enum sdhci_cdns_sd6_phy_lock_mode *lock_mode,
++					     bool *locked,
++					     u8 *dll_lock_value);
++
++static inline void cdns_writel(struct sdhci_cdns_priv *priv, u32 val,
++			       void __iomem *reg)
++{
++	writel(val, reg);
++}
++
++static void init_hs(struct sdhci_cdns_sd6_phy_timings *t, int t_sdclk)
++{
++	*t = (struct sdhci_cdns_sd6_phy_timings){
++		.t_cmd_output_min = 2000, .t_cmd_output_max = t_sdclk - 6000,
++		.t_dat_output_min = 2000, .t_dat_output_max = t_sdclk - 6000,
++		.t_cmd_input_min = 14000, .t_cmd_input_max = t_sdclk + 2500,
++		.t_dat_input_min = 14000, .t_dat_input_max = t_sdclk + 2500,
++		.t_sdclk_min = 1000000 / 50, .t_sdclk_max = 1000000 / 0.4
++	};
++}
++
++static void init_uhs_sdr12(struct sdhci_cdns_sd6_phy_timings *t, int t_sdclk)
++{
++	*t = (struct sdhci_cdns_sd6_phy_timings){
++		.t_cmd_output_min = 800, .t_cmd_output_max = t_sdclk - 3000,
++		.t_dat_output_min = 800, .t_dat_output_max = t_sdclk - 3000,
++		.t_cmd_input_min = 14000, .t_cmd_input_max = t_sdclk + 1500,
++		.t_dat_input_min = 14000, .t_dat_input_max = t_sdclk + 1500,
++		.t_sdclk_min = 1000000 / 25, .t_sdclk_max = 1000000 / 0.4
++	};
++}
++
++static void init_uhs_sdr25(struct sdhci_cdns_sd6_phy_timings *t, int t_sdclk)
++{
++	*t = (struct sdhci_cdns_sd6_phy_timings){
++		.t_cmd_output_min = 800, .t_cmd_output_max = t_sdclk - 3000,
++		.t_dat_output_min = 800, .t_dat_output_max = t_sdclk - 3000,
++		.t_cmd_input_min = 14000, .t_cmd_input_max = t_sdclk + 1500,
++		.t_dat_input_min = 14000, .t_dat_input_max = t_sdclk + 1500,
++		.t_sdclk_min = 1000000 / 50, .t_sdclk_max = 1000000 / 0.4
++	};
++}
++
++static void init_uhs_sdr50(struct sdhci_cdns_sd6_phy_timings *t, int t_sdclk)
++{
++	*t = (struct sdhci_cdns_sd6_phy_timings){
++		.t_cmd_output_min = 800, .t_cmd_output_max = t_sdclk - 3000,
++		.t_dat_output_min = 800, .t_dat_output_max = t_sdclk - 3000,
++		.t_cmd_input_min = 7500, .t_cmd_input_max = t_sdclk + 1500,
++		.t_dat_input_min = 7500, .t_dat_input_max = t_sdclk + 1500,
++		.t_sdclk_min = 1000000 / 100, .t_sdclk_max = 1000000 / 0.4
++	};
++}
++
++static void init_uhs_sdr104(struct sdhci_cdns_sd6_phy_timings *t, int t_sdclk)
++{
++	*t = (struct sdhci_cdns_sd6_phy_timings){
++		.t_cmd_output_min = 800, .t_cmd_output_max = t_sdclk - 1400,
++		.t_dat_output_min = 800, .t_dat_output_max = t_sdclk - 1400,
++		.t_cmd_input_min = 1000, .t_cmd_input_max = t_sdclk + 1000,
++		.t_dat_input_min = 1000, .t_dat_input_max = t_sdclk + 1000,
++		.t_sdclk_min = 1000000 / 200, .t_sdclk_max = 1000000 / 100
++	};
++}
++
++static void init_uhs_ddr50(struct sdhci_cdns_sd6_phy_timings *t, int t_sdclk)
++{
++	*t = (struct sdhci_cdns_sd6_phy_timings){
++		.t_cmd_output_min = 800, .t_cmd_output_max = t_sdclk - 3000,
++		.t_dat_output_min = 800, .t_dat_output_max = t_sdclk - 3000,
++		.t_cmd_input_min = 13700, .t_cmd_input_max = t_sdclk + 1500,
++		.t_dat_input_min = 7000, .t_dat_input_max = t_sdclk + 1500,
++		.t_sdclk_min = 1000000 / 50, .t_sdclk_max = 1000000 / 0.4
++	};
++}
++
++static void init_emmc_legacy(struct sdhci_cdns_sd6_phy_timings *t, int t_sdclk)
++{
++	*t = (struct sdhci_cdns_sd6_phy_timings){
++		.t_cmd_output_min = 3000, .t_cmd_output_max = t_sdclk - 3000,
++		.t_dat_output_min = 3000, .t_dat_output_max = t_sdclk - 3000,
++		.t_cmd_input_min = 11700, .t_cmd_input_max = t_sdclk + 8300,
++		.t_dat_input_min = 11700, .t_dat_input_max = t_sdclk + 8300,
++		.t_sdclk_min = 1000000 / 25, .t_sdclk_max = 1000000 / 0.4
++	};
++}
++
++static void init_emmc_sdr(struct sdhci_cdns_sd6_phy_timings *t, int t_sdclk)
++{
++	*t = (struct sdhci_cdns_sd6_phy_timings){
++		.t_cmd_output_min = 3000, .t_cmd_output_max = t_sdclk - 3000,
++		.t_dat_output_min = 3000, .t_dat_output_max = t_sdclk - 3000,
++		.t_cmd_input_min = 13700, .t_cmd_input_max = t_sdclk + 2500,
++		.t_dat_input_min = 13700, .t_dat_input_max = t_sdclk + 2500,
++		.t_sdclk_min = 1000000 / 50, .t_sdclk_max = 1000000 / 0.4
++	};
++}
++
++static void init_emmc_ddr(struct sdhci_cdns_sd6_phy_timings *t, int t_sdclk)
++{
++	*t = (struct sdhci_cdns_sd6_phy_timings){
++		.t_cmd_output_min = 3000, .t_cmd_output_max = t_sdclk - 3000,
++		.t_dat_output_min = 2500,
++		.t_dat_output_max = (t_sdclk / 2) - 2500,
++		.t_cmd_input_min = 13700, .t_cmd_input_max = t_sdclk + 2500,
++		.t_dat_input_min = 7000, .t_dat_input_max = t_sdclk + 1500,
++		.t_sdclk_min = 1000000 / 50, .t_sdclk_max = 1000000 / 0.4
++	};
++}
++
++static void init_emmc_hs200(struct sdhci_cdns_sd6_phy_timings *t, int t_sdclk)
++{
++	*t = (struct sdhci_cdns_sd6_phy_timings){
++		.t_cmd_output_min = 800, .t_cmd_output_max = t_sdclk - 1400,
++		.t_dat_output_min = 800, .t_dat_output_max = t_sdclk - 1400,
++		.t_cmd_input_min = 1000, .t_cmd_input_max = t_sdclk + 1000,
++		.t_dat_input_min = 1000, .t_dat_input_max = t_sdclk + 1000,
++		.t_sdclk_min = 1000000 / 200, .t_sdclk_max = 1000000 / 100
++	};
++}
++
++/* HS400 and HS400ES */
++static void init_emmc_hs400(struct sdhci_cdns_sd6_phy_timings *t, int t_sdclk)
++{
++	*t = (struct sdhci_cdns_sd6_phy_timings){
++		.t_cmd_output_min = 800, .t_cmd_output_max = t_sdclk - 1400,
++		.t_dat_output_min = 400,
++		.t_dat_output_max = (t_sdclk / 2) - 400,
++		.t_cmd_input_min = 1000, .t_cmd_input_max = t_sdclk + 1000,
++		.t_dat_input_min = 1000, .t_dat_input_max = t_sdclk + 1000,
++		.t_sdclk_min = 1000000 / 200, .t_sdclk_max = 1000000 / 100
++	};
++}
++
++static void (*init_timings[])(struct sdhci_cdns_sd6_phy_timings*, int) = {
++	&init_hs, &init_emmc_legacy, &init_emmc_sdr,
++	&init_emmc_ddr, &init_emmc_hs200, &init_emmc_hs400,
++	&init_uhs_sdr12, &init_uhs_sdr25, &init_uhs_sdr50,
++	&init_uhs_sdr104, &init_uhs_ddr50
++};
++
++static u32 read_dqs_cmd_delay, clk_wrdqs_delay, clk_wr_delay, read_dqs_delay;
++static u32 read_dqs_cmd_delay_hs400, read_dqs_delay_hs400;
++static u32 clk_wrdqs_delay_hs400, clk_wr_delay_hs400;
++
++static u32 sdhci_cdns_sd6_get_mode(struct sdhci_host *host,
++				   unsigned int timing);
++
++#ifdef CONFIG_MMC_SDHCI_IO_ACCESSORS
++static u32 sdhci_cdns_sd6_readl(struct sdhci_host *host, int reg)
++{
++	return readl(host->ioaddr + reg);
++}
++
++static void sdhci_cdns_sd6_writel(struct sdhci_host *host, u32 val, int reg)
++{
++	writel(val, host->ioaddr + reg);
++}
++
++static u16 sdhci_cdns_sd6_readw(struct sdhci_host *host, int reg)
++{
++	u32 val, regoff;
++
++	regoff = reg & ~3;
++
++	val = readl(host->ioaddr + regoff);
++	if ((reg & 0x3) == 0)
++		return (val & 0xFFFF);
++	else
++		return ((val >> 16) & 0xFFFF);
++}
++
++static void sdhci_cdns_sd6_writew(struct sdhci_host *host, u16 val, int reg)
++{
++	writew(val, host->ioaddr + reg);
++}
++
++static u8 sdhci_cdns_sd6_readb(struct sdhci_host *host, int reg)
++{
++	u32 val, regoff;
++
++	regoff = reg & ~3;
++
++	val = readl(host->ioaddr + regoff);
++	switch (reg & 3) {
++	case 0:
++		return (val & 0xFF);
++	case 1:
++		return ((val >> 8) & 0xFF);
++	case 2:
++		return ((val >> 16) & 0xFF);
++	case 3:
++		return ((val >> 24) & 0xFF);
++	}
++	return 0;
++}
++
++static void sdhci_cdns_sd6_writeb(struct sdhci_host *host, u8 val, int reg)
++{
++	writeb(val, host->ioaddr + reg);
++}
++#endif
++
++static void *sdhci_cdns_priv(struct sdhci_host *host)
++{
++	struct sdhci_pltfm_host *pltfm_host = sdhci_priv(host);
++
++	return sdhci_pltfm_priv(pltfm_host);
++}
++
++static int sdhci_cdns_sd6_phy_lock_dll(struct sdhci_cdns_priv *priv)
++{
++	struct sdhci_cdns_sd6_phy *phy = priv->phy;
++	u32 delay_element = phy->d.delay_element;
++	u32 delay_elements_in_sdmclk;
++	int ret;
++	enum sdhci_cdns_sd6_phy_lock_mode mode;
++	bool locked = false;
++	u8 dll_lock_value = 0xff;
++
++	ret = sdhci_cdns_sd6_get_dll_parameters(priv, &mode, &locked,
++						&dll_lock_value);
++	if (ret) {
++		pr_err("%s: Could not get DLL parameters\n", __func__);
++		return ret;
++	}
++
++	if (locked) {
++		/*
++		 * If we have lock then we use units of 1/256 or 1/128
++		 * depending if we're in full or half clock mode.
++		 * For now, saturation mode is treated like full clock mode
++		 * though this may be incorrect.
++		 */
++		if (mode == SDHCI_CDNS_SD6_PHY_LOCK_MODE_FULL_CLK) {
++			DEBUG_DRV("%s: PHY DLL locked in full clock mode\n",
++				  __func__);
++			delay_elements_in_sdmclk = 256;
++			phy->vars.dll_max_value = 255;
++			tune_val_step = SDHCI_CDNS_TUNE_STEP;
++		} else if (mode == SDHCI_CDNS_SD6_PHY_LOCK_MODE_HALF_CLK) {
++			DEBUG_DRV("%s: PHY DLL locked in half clock mode\n",
++				  __func__);
++			delay_elements_in_sdmclk = 128;
++			phy->vars.dll_max_value = 127;
++			tune_val_step = SDHCI_CDNS_TUNE_STEP / 2;
++		} else {
++			DEBUG_DRV("%s: PHY DLL locked in saturation mode.\n",
++				  __func__);
++			delay_elements_in_sdmclk = 256;
++			phy->vars.dll_max_value = 255;
++			tune_val_step = SDHCI_CDNS_TUNE_STEP;
++		}
++		/* No bypass if we're locked */
++		phy->settings.cp_dll_bypass_mode = 0;
++		phy->vars.t_sdmclk_calc = phy->t_sdmclk;
++		DEBUG_DRV("%s: t_sdmclk_calc: %u\n",
++			  __func__, phy->vars.t_sdmclk_calc);
++	} else {
++		/*
++		 * Since we do not have a DLL lock we must use delay elements.
++		 * The delay element count for a 250MHz clock period was
++		 * determined earlier, so we calculate the delay in terms of
++		 * the number of delay elements.
++		 */
++		DEBUG_DRV("%s: PHY DLL not locked, using delay element %u\n",
++			  __func__, delay_element);
++		delay_elements_in_sdmclk = DIV_ROUND_UP(phy->t_sdmclk,
++							delay_element);
++		DEBUG_DRV("%s: delay elements in sdmclk: %u\n",
++			  __func__, delay_elements_in_sdmclk);
++		if (delay_elements_in_sdmclk > 256) {
++			DEBUG_DRV("%s: delay elem in sdmclk %u > 256, delay elem %u\n",
++				  __func__, delay_elements_in_sdmclk,
++				  delay_element);
++			delay_element *= 2;
++			DEBUG_DRV("%s: doubling delay_element to %u\n",
++				  __func__, delay_element);
++			delay_elements_in_sdmclk = DIV_ROUND_UP(phy->t_sdmclk,
++								delay_element);
++
++			if (delay_elements_in_sdmclk > 256) {
++				DEBUG_DRV("%s: WARN sdmclk delay elems %u > 256; clamp it\n",
++					  __func__, delay_elements_in_sdmclk);
++				delay_elements_in_sdmclk = 256;
++			}
++			mode = SDHCI_CDNS_SD6_PHY_LOCK_MODE_HALF_CLK;
++			phy->vars.dll_max_value = 127;
++			DEBUG_DRV("%s: delay_element_in_sdmclk now %u\n",
++				  __func__, delay_elements_in_sdmclk);
++		} else {
++			mode = SDHCI_CDNS_SD6_PHY_LOCK_MODE_FULL_CLK;
++			phy->vars.dll_max_value = 255;
++		}
++		/* Bypass if no lock */
++		phy->settings.cp_dll_bypass_mode = 1;
++		phy->vars.t_sdmclk_calc = delay_element *
++					  delay_elements_in_sdmclk;
++		phy->d.delay_element = delay_element;
++	}
++	delay_elements_in_sdmclk = DIV_ROUND_UP(phy->t_sdmclk, delay_element);
++	if (delay_elements_in_sdmclk > 256) {
++		delay_element *= 2;
++		delay_elements_in_sdmclk = DIV_ROUND_UP(phy->t_sdmclk,
++							delay_element);
++
++		if (delay_elements_in_sdmclk > 256)
++			return -1;
++
++		mode = SDHCI_CDNS_SD6_PHY_LOCK_MODE_HALF_CLK;
++		phy->vars.dll_max_value = 127;
++	} else {
++		mode = SDHCI_CDNS_SD6_PHY_LOCK_MODE_FULL_CLK;
++		phy->vars.dll_max_value = 255;
++	}
++
++	phy->vars.t_sdmclk_calc = delay_element * delay_elements_in_sdmclk;
++	phy->d.delay_element = delay_element;
++	phy->settings.cp_dll_locked_mode = mode;
++	phy->settings.cp_dll_bypass_mode = 0;
++
++	return 0;
++}
++
++static void sdhci_cdns_sd6_phy_dll_bypass(struct sdhci_cdns_sd6_phy *phy)
++{
++	phy->vars.dll_max_value = 256;
++	phy->settings.cp_dll_bypass_mode = 1;
++	phy->settings.cp_dll_locked_mode =
++		SDHCI_CDNS_SD6_PHY_LOCK_MODE_SATURATION;
++}
++
++static void sdhci_cdns_sd6_phy_configure_dll(struct sdhci_cdns_priv *priv)
++{
++	struct sdhci_cdns_sd6_phy *phy = priv->phy;
++
++	if (phy->settings.sdhc_extended_wr_mode == 0) {
++		if (sdhci_cdns_sd6_phy_lock_dll(priv) == 0)
++			return;
++	}
++	sdhci_cdns_sd6_phy_dll_bypass(phy);
++}
++
++static void sdhci_cdns_sd6_phy_calc_out(struct sdhci_cdns_sd6_phy *phy,
++					bool cmd_not_dat)
++{
++	u32 wr0_dly = 0, wr1_dly = 0, output_min, output_max, phy_o_delay,
++	    clk_wr_delay = 0, wr0_sdclk_dly = 0, wr1_sdclk_dly = 0;
++	bool data_ddr = phy->ddr && !cmd_not_dat;
++	int t;
++
++	if (cmd_not_dat) {
++		output_min = phy->t.t_cmd_output_min;
++		output_max = phy->t.t_cmd_output_max;
++		phy_o_delay = phy->d.phy_cmd_o_delay;
++	} else {
++		output_min = phy->t.t_dat_output_min;
++		output_max = phy->t.t_dat_output_max;
++		phy_o_delay = phy->d.phy_dat_o_delay;
++	}
++
++	clk_wr_delay = 0;
++	if (data_ddr) {
++		wr0_sdclk_dly = 1;
++		wr1_sdclk_dly = 1;
++	}
++
++	t = phy_o_delay - phy->d.phy_sdclk_delay - output_min;
++	if (t < 0 && phy->settings.sdhc_extended_wr_mode == 1) {
++		u32 n_half_cycle = DIV_ROUND_UP(-t * 2, phy->t_sdmclk);
++
++		wr0_dly = (n_half_cycle + 1) / 2;
++		if (data_ddr)
++			wr1_dly = (n_half_cycle + 1) / 2;
++		else
++			wr1_dly = (n_half_cycle + 1) % 2 + wr0_dly - 1;
++	}
++
++	if (phy->settings.sdhc_extended_wr_mode == 0) {
++		u32 out_hold, out_setup, out_hold_margin;
++		u32 n;
++
++		if (!data_ddr)
++			wr0_dly = 1;
++
++		out_setup = output_max;
++		out_hold = output_min;
++		out_hold_margin = DIV_ROUND_UP(out_setup - out_hold, 4);
++		out_hold += out_hold_margin;
++
++		if (phy->settings.cp_dll_bypass_mode == 0)
++			n = DIV_ROUND_UP(256 * out_hold,
++					 phy->vars.t_sdmclk_calc);
++		else
++			n = DIV_ROUND_UP(out_hold, phy->d.delay_element) - 1;
++
++		if (n <= phy->vars.dll_max_value)
++			clk_wr_delay = n;
++		else
++			clk_wr_delay = 255;
++	} else {
++		/*  sdhc_extended_wr_mode = 1 - PHY IO cell work in SDR mode */
++		clk_wr_delay = 0;
++	}
++
++	if (cmd_not_dat) {
++		phy->settings.sdhc_wrcmd0_dly = wr0_dly;
++		phy->settings.sdhc_wrcmd1_dly = wr1_dly;
++		phy->settings.cp_clk_wrdqs_delay = clk_wr_delay;
++		phy->settings.sdhc_wrcmd0_sdclk_dly = wr0_sdclk_dly;
++		phy->settings.sdhc_wrcmd1_sdclk_dly = wr1_sdclk_dly;
++	} else {
++		phy->settings.sdhc_wrdata0_dly = wr0_dly;
++		phy->settings.sdhc_wrdata1_dly = wr1_dly;
++		phy->settings.cp_clk_wr_delay = clk_wr_delay;
++		phy->settings.sdhc_wrdata0_sdclk_dly = wr0_sdclk_dly;
++		phy->settings.sdhc_wrdata1_sdclk_dly = wr1_sdclk_dly;
++	}
++
++	if (phy->mode == MMC_TIMING_MMC_HS400 && cmd_not_dat) {
++		phy->settings.cp_clk_wrdqs_delay =
++			clk_wrdqs_delay_hs400 ? clk_wrdqs_delay_hs400 :
++						clk_wr_delay;
++		DEBUG_DRV("%s:cp_clk_wrdqs_delay %d clk_wrdqs_delay_hs400 %d\n",
++			  __func__, phy->settings.cp_clk_wrdqs_delay,
++			  clk_wrdqs_delay_hs400);
++	} else if (phy->mode == MMC_TIMING_MMC_HS400 && !cmd_not_dat) {
++		phy->settings.cp_clk_wr_delay =
++			clk_wr_delay_hs400 ? clk_wr_delay_hs400 : clk_wr_delay;
++		DEBUG_DRV("%s:cp_clk_wr_delay %d  clk_wr_delay_hs400 %d\n",
++			  __func__, phy->settings.cp_clk_wr_delay,
++			  clk_wr_delay_hs400);
++	}
++}
++
++static void sdhci_cdns_sd6_phy_calc_cmd_out(struct sdhci_cdns_sd6_phy *phy)
++{
++	sdhci_cdns_sd6_phy_calc_out(phy, true);
++}
++
++static void sdhci_cdns_sd6_phy_calc_cmd_in(struct sdhci_cdns_sd6_phy *phy)
++{
++	phy->settings.cp_io_mask_end =
++		((phy->d.iocell_output_delay + phy->d.iocell_input_delay) * 2)
++		/ phy->t_sdmclk;
++
++	if (phy->settings.cp_io_mask_end >= 8)
++		phy->settings.cp_io_mask_end = 7;
++
++	if (phy->strobe_cmd && phy->settings.cp_io_mask_end > 0)
++		phy->settings.cp_io_mask_end--;
++
++	if (phy->strobe_cmd) {
++		phy->settings.cp_use_phony_dqs_cmd = 0;
++		phy->settings.cp_read_dqs_cmd_delay = read_dqs_cmd_delay_hs400;
++	} else {
++		phy->settings.cp_use_phony_dqs_cmd = 1;
++		phy->settings.cp_read_dqs_cmd_delay = 0;
++	}
++
++	if ((phy->mode == MMC_TIMING_MMC_HS400 && !phy->strobe_cmd) ||
++	    phy->mode == MMC_TIMING_MMC_HS200)
++		phy->settings.cp_read_dqs_cmd_delay =
++			phy->settings.hs200_tune_val;
++}
++
++static void sdhci_cdns_sd6_phy_calc_dat_in(struct sdhci_cdns_sd6_phy *phy)
++{
++	u32 hcsdclkadj = 0;
++
++	if (phy->strobe_dat) {
++		phy->settings.cp_use_phony_dqs = 0;
++		phy->settings.cp_read_dqs_delay = read_dqs_delay_hs400;
++	} else {
++		phy->settings.cp_use_phony_dqs = 1;
++		phy->settings.cp_read_dqs_delay = 0;
++	}
++
++	if (phy->mode == MMC_TIMING_MMC_HS200)
++		phy->settings.cp_read_dqs_delay =
++			phy->settings.hs200_tune_val;
++
++	if (phy->strobe_dat) {
++		/* dqs loopback input via IO cell */
++		hcsdclkadj += phy->d.iocell_input_delay;
++		/*
++		 * dfi_dqs_in: mem_dqs -> clean_dqs_mod;
++		 * hic_dll_dqs_nand2 delay
++		 */
++		hcsdclkadj += phy->d.delay_element / 2;
++		/* delay line */
++		hcsdclkadj += phy->t_sdclk / 2;
++		/* PHY FIFO write pointer */
++		hcsdclkadj += phy->t_sdclk / 2 + phy->d.delay_element;
++		/* 1st synchronizer */
++		hcsdclkadj += DIV_ROUND_UP(hcsdclkadj, phy->t_sdmclk)
++			* phy->t_sdmclk - hcsdclkadj;
++		/*
++		 * 2nd synchronizer + PHY FIFO read pointer + PHY rddata
++		 * + PHY rddata registered, + FIFO 1st ciu_en
++		 */
++		hcsdclkadj += 5 * phy->t_sdmclk;
++		/* FIFO 2st ciu_en */
++		hcsdclkadj += phy->t_sdclk;
++
++		hcsdclkadj /= phy->t_sdclk;
++	} else {
++		u32 n;
++
++		/* rebar PHY delay */
++		hcsdclkadj += 2 * phy->t_sdmclk;
++		/* rebar output via IO cell */
++		hcsdclkadj += phy->d.iocell_output_delay;
++		/* dqs loopback input via IO cell */
++		hcsdclkadj += phy->d.iocell_input_delay;
++		/*
++		 * dfi_dqs_in: mem_dqs -> clean_dqs_mod,
++		 * hic_dll_dqs_nand2 delay
++		 */
++		hcsdclkadj += phy->d.delay_element / 2;
++		/* dll: one delay element between SIGI_0 and SIGO_0 */
++		hcsdclkadj += phy->d.delay_element;
++		/*
++		 * dfi_dqs_in: mem_dqs_delayed -> clk_dqs,
++		 * hic_dll_dqs_nand2 delay
++		 */
++		hcsdclkadj += phy->d.delay_element / 2;
++		/* deskew DLL: clk_dqs -> clk_dqN: one delay element */
++		hcsdclkadj += phy->d.delay_element;
++
++		if (phy->t_sdclk == phy->t_sdmclk)
++			n = (hcsdclkadj - 2 * phy->t_sdmclk) / phy->t_sdclk;
++		else
++			n = hcsdclkadj / phy->t_sdclk;
++
++		/* phase shift in one t_sdclk from rebar/lbk dqs delay */
++		hcsdclkadj = hcsdclkadj % phy->t_sdclk;
++		/* PHY FIFO write pointer */
++		hcsdclkadj += phy->t_sdclk / 2;
++		/* 1st synchronizer */
++		hcsdclkadj += DIV_ROUND_UP(hcsdclkadj, phy->t_sdmclk)
++			* phy->t_sdmclk - hcsdclkadj;
++		/*
++		 * 2nd synchronizer + PHY FIFO read pointer + PHY rddata
++		 * + PHY rddata registered
++		 */
++		hcsdclkadj += 4 * phy->t_sdmclk;
++
++		if ((phy->t_sdclk / phy->t_sdmclk) > 1) {
++			u32 tmp1, tmp2;
++
++			tmp1 = hcsdclkadj;
++			tmp2 = (hcsdclkadj / phy->t_sdclk) * phy->t_sdclk
++				+ phy->t_sdclk - phy->t_sdmclk;
++			if (tmp1 == tmp2)
++				tmp2 += phy->t_sdclk;
++
++			/* FIFO aligns to clock cycle before ciu_en */
++			hcsdclkadj += tmp2 - tmp1;
++		}
++
++		/* FIFO 1st ciu_en */
++		hcsdclkadj += phy->t_sdmclk;
++		/* FIFO 2nd ciu_en */
++		hcsdclkadj += phy->t_sdclk;
++
++		hcsdclkadj /= phy->t_sdclk;
++
++		hcsdclkadj += n;
++
++		if ((phy->t_sdclk / phy->t_sdmclk) >= 2) {
++			if (phy->mode == MMC_TIMING_UHS_DDR50 ||
++			    phy->mode == MMC_TIMING_MMC_DDR52)
++				hcsdclkadj -= 2;
++			else
++				hcsdclkadj -= 1;
++		} else if ((phy->t_sdclk / phy->t_sdmclk) == 1) {
++			hcsdclkadj += 2;
++		}
++
++		if (phy->tune_dat)
++			hcsdclkadj -= 1;
++	}
++
++	if (hcsdclkadj > 15)
++		hcsdclkadj = 15;
++
++	phy->settings.sdhc_hcsdclkadj = hcsdclkadj;
++}
++
++static void sdhci_cdns_sd6_phy_calc_dat_out(struct sdhci_cdns_sd6_phy *phy)
++{
++	sdhci_cdns_sd6_phy_calc_out(phy, false);
++}
++
++static void sdhci_cdns_sd6_phy_calc_io(struct sdhci_cdns_sd6_phy *phy)
++{
++	u32 rw_compensate;
++
++	rw_compensate = (phy->d.iocell_input_delay + phy->d.iocell_output_delay)
++		/ phy->t_sdmclk + phy->settings.sdhc_wrdata0_dly + 5 + 3;
++
++	phy->settings.sdhc_idelay_val = (2 * phy->d.iocell_input_delay)
++		/ phy->t_sdmclk;
++
++	phy->settings.cp_io_mask_start = 0;
++	if (phy->t_sdclk == phy->t_sdmclk && rw_compensate > 10)
++		phy->settings.cp_io_mask_start = 2 * (rw_compensate - 10);
++
++	if (phy->mode == MMC_TIMING_UHS_SDR104)
++		phy->settings.cp_io_mask_start++;
++
++	if (phy->t_sdclk == phy->t_sdmclk && phy->mode == MMC_TIMING_UHS_SDR50)
++		phy->settings.cp_io_mask_start++;
++
++	phy->settings.sdhc_rw_compensate = rw_compensate;
++}
++
++static void sdhci_cdns_sd6_phy_calc_settings(struct sdhci_cdns_sd6_phy *phy)
++{
++	sdhci_cdns_sd6_phy_calc_cmd_out(phy);
++	sdhci_cdns_sd6_phy_calc_cmd_in(phy);
++	sdhci_cdns_sd6_phy_calc_dat_out(phy);
++	sdhci_cdns_sd6_phy_calc_dat_in(phy);
++	sdhci_cdns_sd6_phy_calc_io(phy);
++}
++
++static int sdhci_cdns_sd4_write_phy_reg(struct sdhci_cdns_priv *priv,
++					u8 addr, u8 data)
++{
++	void __iomem *reg = priv->hrs_addr + SDHCI_CDNS_HRS04;
++	u32 tmp;
++	int ret;
++
++	ret = readl_poll_timeout(reg, tmp, !(tmp & SDHCI_CDNS_SD4_HRS04_ACK),
++				 0, 10);
++	if (ret)
++		return ret;
++
++	tmp = FIELD_PREP(SDHCI_CDNS_SD4_HRS04_WDATA, data) |
++	      FIELD_PREP(SDHCI_CDNS_SD4_HRS04_ADDR, addr);
++	priv->priv_writel(priv, tmp, reg);
++
++	tmp |= SDHCI_CDNS_SD4_HRS04_WR;
++	priv->priv_writel(priv, tmp, reg);
++
++	ret = readl_poll_timeout(reg, tmp, tmp & SDHCI_CDNS_SD4_HRS04_ACK,
++				 0, 10);
++	if (ret)
++		return ret;
++
++	tmp &= ~SDHCI_CDNS_SD4_HRS04_WR;
++	priv->priv_writel(priv, tmp, reg);
++
++	ret = readl_poll_timeout(reg, tmp, !(tmp & SDHCI_CDNS_SD4_HRS04_ACK),
++				 0, 10);
++
++	return ret;
++}
++
++static unsigned int sdhci_cdns_sd4_phy_param_count(struct device *dev)
++{
++	unsigned int count = 0;
++	int i;
++
++	for (i = 0; i < ARRAY_SIZE(sdhci_cdns_sd4_phy_cfgs); i++)
++		if (device_property_read_bool(dev,
++					      sdhci_cdns_sd4_phy_cfgs[i].property))
++			count++;
++
++	return count;
++}
++
++static void sdhci_cdns_sd4_phy_param_parse(struct device *dev,
++					   struct sdhci_cdns_priv *priv)
++{
++	struct sdhci_cdns_sd4_phy_param *p = priv->phy_params;
++	u32 val;
++	int ret, i;
++
++	for (i = 0; i < ARRAY_SIZE(sdhci_cdns_sd4_phy_cfgs); i++) {
++		ret = device_property_read_u32(dev,
++					       sdhci_cdns_sd4_phy_cfgs[i].property,
++					       &val);
++		if (ret)
++			continue;
++
++		p->addr = sdhci_cdns_sd4_phy_cfgs[i].addr;
++		p->data = val;
++		p++;
++	}
++}
++
++static int sdhci_cdns_sd4_phy_init(struct sdhci_cdns_priv *priv)
++{
++	int ret, i;
++
++	for (i = 0; i < priv->nr_phy_params; i++) {
++		ret = sdhci_cdns_sd4_write_phy_reg(priv,
++						   priv->phy_params[i].addr,
++						   priv->phy_params[i].data);
++		if (ret)
++			return ret;
++	}
++	return 0;
++}
++
++static u32 sdhci_cdns_sd6_read_phy_reg(struct sdhci_cdns_priv *priv,
++				       u32 addr)
++{
++	writel(FIELD_PREP(SDHCI_CDNS_SD6_HRS04_ADDR, addr),
++	       priv->hrs_addr + SDHCI_CDNS_HRS04);
++	return readl(priv->hrs_addr + SDHCI_CDNS_HRS05);
++}
++
++static void sdhci_cdns_sd6_write_phy_reg(struct sdhci_cdns_priv *priv,
++					 u32 addr, u32 data)
++{
++	writel(FIELD_PREP(SDHCI_CDNS_SD6_HRS04_ADDR, addr),
++	       priv->hrs_addr + SDHCI_CDNS_HRS04);
++	writel(data, priv->hrs_addr + SDHCI_CDNS_HRS05);
++}
++
++static int sdhci_cdns_sd6_dll_reset(struct sdhci_cdns_priv *priv, bool reset)
++{
++	u32 reg;
++	int ret = 0;
++
++	reg = readl(priv->hrs_addr + SDHCI_CDNS_HRS09);
++	if (reset)
++		reg &= ~SDHCI_CDNS_HRS09_PHY_SW_RESET;
++	else
++		reg |= SDHCI_CDNS_HRS09_PHY_SW_RESET;
++
++	writel(reg, priv->hrs_addr + SDHCI_CDNS_HRS09);
++
++	if (!reset)
++		ret = readl_poll_timeout(priv->hrs_addr + SDHCI_CDNS_HRS09,
++					 reg,
++					 (reg &
++					  SDHCI_CDNS_HRS09_PHY_INIT_COMPLETE),
++					 0, 0);
++
++	return ret;
++}
++
++static void sdhci_cdns_sd6_calc_phy(struct sdhci_cdns_sd6_phy *phy)
++{
++	if (phy->mode == MMC_TIMING_MMC_HS) {
++		phy->settings.cp_clk_wr_delay = 0;
++		phy->settings.cp_clk_wrdqs_delay = 0;
++		phy->settings.cp_data_select_oe_end = 1;
++		phy->settings.cp_dll_bypass_mode = 1;
++		phy->settings.cp_dll_locked_mode = 3;
++		phy->settings.cp_dll_start_point = 4;
++		phy->settings.cp_gate_cfg_always_on = 1;
++		phy->settings.cp_io_mask_always_on = 0;
++		phy->settings.cp_io_mask_end = 0;
++		phy->settings.cp_io_mask_start = 0;
++		phy->settings.cp_rd_del_sel = 52;
++		phy->settings.cp_read_dqs_cmd_delay = 0;
++		phy->settings.cp_read_dqs_delay = 0;
++		phy->settings.cp_sw_half_cycle_shift = 0;
++		phy->settings.cp_sync_method = 1;
++		phy->settings.cp_underrun_suppress = 1;
++		phy->settings.cp_use_ext_lpbk_dqs = 1;
++		phy->settings.cp_use_lpbk_dqs = 1;
++		phy->settings.cp_use_phony_dqs = 1;
++		phy->settings.cp_use_phony_dqs_cmd = 1;
++		phy->settings.sdhc_extended_rd_mode = 1;
++		phy->settings.sdhc_extended_wr_mode = 1;
++		phy->settings.sdhc_hcsdclkadj = 2;
++		phy->settings.sdhc_idelay_val = 0;
++		phy->settings.sdhc_rdcmd_en = 1;
++		phy->settings.sdhc_rddata_en = 1;
++		phy->settings.sdhc_rw_compensate = 9;
++		phy->settings.sdhc_sdcfsh = 0;
++		phy->settings.sdhc_sdcfsl = 4;
++		phy->settings.sdhc_wrcmd0_dly = 1;
++		phy->settings.sdhc_wrcmd0_sdclk_dly = 0;
++		phy->settings.sdhc_wrcmd1_dly = 0;
++		phy->settings.sdhc_wrcmd1_sdclk_dly = 0;
++		phy->settings.sdhc_wrdata0_dly = 1;
++		phy->settings.sdhc_wrdata0_sdclk_dly = 0;
++		phy->settings.sdhc_wrdata1_dly = 0;
++		phy->settings.sdhc_wrdata1_sdclk_dly = 0;
++	}
++}
++
++#ifdef CONFIG_MMC_SDHCI_CADENCE_DEBUG
++static void sdhci_cdns_sd6_phy_dump(struct sdhci_cdns_sd6_phy *phy)
++{
++	DEBUG_DRV("PHY Timings\n");
++	DEBUG_DRV("mode %d t_sdclk %d\n", phy->mode, phy->t_sdclk);
++
++	DEBUG_DRV("cp_clk_wr_delay %d\n", phy->settings.cp_clk_wr_delay);
++	DEBUG_DRV("cp_clk_wrdqs_delay %d\n",
++		  phy->settings.cp_clk_wrdqs_delay);
++	DEBUG_DRV("cp_data_select_oe_end %d\n",
++		  phy->settings.cp_data_select_oe_end);
++	DEBUG_DRV("cp_dll_bypass_mode %d\n",
++		  phy->settings.cp_dll_bypass_mode);
++	DEBUG_DRV("cp_dll_locked_mode %d\n",
++		  phy->settings.cp_dll_locked_mode);
++	DEBUG_DRV("cp_dll_start_point %d\n",
++		  phy->settings.cp_dll_start_point);
++	DEBUG_DRV("cp_io_mask_always_on %d\n",
++		  phy->settings.cp_io_mask_always_on);
++	DEBUG_DRV("cp_io_mask_end %d\n", phy->settings.cp_io_mask_end);
++	DEBUG_DRV("cp_io_mask_start %d\n", phy->settings.cp_io_mask_start);
++	DEBUG_DRV("cp_rd_del_sel %d\n", phy->settings.cp_rd_del_sel);
++	DEBUG_DRV("cp_read_dqs_cmd_delay %d\n",
++		  phy->settings.cp_read_dqs_cmd_delay);
++	DEBUG_DRV("cp_read_dqs_delay %d\n",
++		  phy->settings.cp_read_dqs_delay);
++	DEBUG_DRV("cp_sw_half_cycle_shift %d\n",
++		  phy->settings.cp_sw_half_cycle_shift);
++	DEBUG_DRV("cp_sync_method %d\n", phy->settings.cp_sync_method);
++	DEBUG_DRV("cp_use_ext_lpbk_dqs %d\n",
++		  phy->settings.cp_use_ext_lpbk_dqs);
++	DEBUG_DRV("cp_use_lpbk_dqs %d\n", phy->settings.cp_use_lpbk_dqs);
++	DEBUG_DRV("cp_use_phony_dqs %d\n", phy->settings.cp_use_phony_dqs);
++	DEBUG_DRV("cp_use_phony_dqs_cmd %d\n",
++		  phy->settings.cp_use_phony_dqs_cmd);
++	DEBUG_DRV("sdhc_extended_rd_mode %d\n",
++		  phy->settings.sdhc_extended_rd_mode);
++	DEBUG_DRV("sdhc_extended_wr_mode %d\n",
++		  phy->settings.sdhc_extended_wr_mode);
++
++	DEBUG_DRV("sdhc_hcsdclkadj %d\n", phy->settings.sdhc_hcsdclkadj);
++	DEBUG_DRV("sdhc_idelay_val %d\n", phy->settings.sdhc_idelay_val);
++	DEBUG_DRV("sdhc_rdcmd_en %d\n", phy->settings.sdhc_rdcmd_en);
++	DEBUG_DRV("sdhc_rddata_en %d\n", phy->settings.sdhc_rddata_en);
++	DEBUG_DRV("sdhc_rw_compensate %d\n", phy->settings.sdhc_rw_compensate);
++	DEBUG_DRV("sdhc_sdcfsh %d\n", phy->settings.sdhc_sdcfsh);
++	DEBUG_DRV("sdhc_sdcfsl %d\n", phy->settings.sdhc_sdcfsl);
++	DEBUG_DRV("sdhc_wrcmd0_dly %d %d\n", phy->settings.sdhc_wrcmd0_dly,
++		  phy->settings.sdhc_wrcmd0_sdclk_dly);
++	DEBUG_DRV("sdhc_wrcmd1_dly %d %d\n", phy->settings.sdhc_wrcmd1_dly,
++		  phy->settings.sdhc_wrcmd1_sdclk_dly);
++	DEBUG_DRV("sdhc_wrdata0_dly %d %d\n", phy->settings.sdhc_wrdata0_dly,
++		  phy->settings.sdhc_wrdata0_sdclk_dly);
++	DEBUG_DRV("sdhc_wrdata1_dly %d %d\n", phy->settings.sdhc_wrdata1_dly,
++		  phy->settings.sdhc_wrdata1_sdclk_dly);
++	DEBUG_DRV("hs200_tune_val %d\n", phy->settings.hs200_tune_val);
++}
++
++void sdhci_cdns_sd6_dump(struct sdhci_cdns_priv *priv)
++{
++	struct sdhci_cdns_sd6_phy *phy = priv->phy;
++	int id;
++
++	sdhci_cdns_sd6_phy_dump(phy);
++
++	DEBUG_DRV("Host controller Register Dump\n");
++	for (id = 0; id < 14; id++)
++		DEBUG_DRV("HRS%d 0x%x\n", id, readl(priv->hrs_addr + (id * 4)));
++
++	id = 29;
++	DEBUG_DRV("HRS%d 0x%x\n", id, readl(priv->hrs_addr + (id * 4)));
++	id = 30;
++	DEBUG_DRV("HRS%d 0x%x\n", id, readl(priv->hrs_addr + (id * 4)));
++
++	for (id = 0; id < 27; id++)
++		DEBUG_DRV("SRS%d 0x%x\n", id,
++			  readl(priv->hrs_addr + 0x200 + (id * 4)));
++
++	DEBUG_DRV("SDHCI_CDNS_SD6_PHY_DQS_TIMING 0x%x\n",
++		  sdhci_cdns_sd6_read_phy_reg(priv, SDHCI_CDNS_SD6_PHY_DQS_TIMING));
++	DEBUG_DRV("SDHCI_CDNS_SD6_PHY_GATE_LPBK 0x%x\n",
++		  sdhci_cdns_sd6_read_phy_reg(priv, SDHCI_CDNS_SD6_PHY_GATE_LPBK));
++	DEBUG_DRV("SDHCI_CDNS_SD6_PHY_DLL_MASTER 0x%x\n",
++		  sdhci_cdns_sd6_read_phy_reg(priv, SDHCI_CDNS_SD6_PHY_DLL_MASTER));
++	DEBUG_DRV("SDHCI_CDNS_SD6_PHY_DLL_SLAVE 0x%x\n",
++		  sdhci_cdns_sd6_read_phy_reg(priv, SDHCI_CDNS_SD6_PHY_DLL_SLAVE));
++	DEBUG_DRV("SDHCI_CDNS_SD6_PHY_CTRL 0x%x\n",
++		  sdhci_cdns_sd6_read_phy_reg(priv, SDHCI_CDNS_SD6_PHY_CTRL));
++	DEBUG_DRV("SDHCI_CDNS_SD6_PHY_GPIO_CTRL0 0x%x\n",
++		  sdhci_cdns_sd6_read_phy_reg(priv, SDHCI_CDNS_SD6_PHY_GPIO_CTRL0));
++	DEBUG_DRV("SDHCI_CDNS_SD6_PHY_DQ_TIMING 0x%x\n",
++		  sdhci_cdns_sd6_read_phy_reg(priv, SDHCI_CDNS_SD6_PHY_DQ_TIMING));
++	DEBUG_DRV("SDHCI_CDNS_SD6_PHY_DLL_OBS_REG0 0x%x\n",
++		  sdhci_cdns_sd6_read_phy_reg(priv, SDHCI_CDNS_SD6_PHY_DLL_OBS_REG0));
++	DEBUG_DRV("SDHCI_CDNS_SD6_PHY_DLL_OBS_REG1 0x%x\n",
++		  sdhci_cdns_sd6_read_phy_reg(priv, SDHCI_CDNS_SD6_PHY_DLL_OBS_REG1));
++	DEBUG_DRV("SDHCI_CDNS_SD6_PHY_DLL_OBS_REG2 0x%x\n",
++		  sdhci_cdns_sd6_read_phy_reg(priv, SDHCI_CDNS_SD6_PHY_DLL_OBS_REG2));
++}
++#endif
++
++static int sdhci_cdns_sd6_get_dll_parameters(struct sdhci_cdns_priv *priv,
++					     enum sdhci_cdns_sd6_phy_lock_mode *lock_mode,
++					     bool *locked,
++					     u8 *dll_lock_value)
++{
++	int timeout_value = 1000;
++	int reg;
++	u8 tmp_lock_value = 0;
++
++	*dll_lock_value = 0xff;
++
++	do {
++		reg = sdhci_cdns_sd6_read_phy_reg(priv, SDHCI_CDNS_SD6_PHY_DLL_OBS_REG0);
++		*locked = !!FIELD_GET(SDHCI_CDNS_SD6_PHY_DLL_OBS_REG0_DLL_LOCK, reg);
++		*lock_mode = FIELD_GET(SDHCI_CDNS_SD6_PHY_DLL_OBS_REG0_DLL_LOCK_MODE, reg);
++		tmp_lock_value = FIELD_GET(SDHCI_CDNS_SD6_PHY_DLL_OBS_REG0_DLL_LOCK_VALUE, reg);
++
++		if (*dll_lock_value != tmp_lock_value)
++			*dll_lock_value = tmp_lock_value;
++		else
++			return 0;
++	} while (timeout_value-- > 0);
++
++	return -1;
++}
++
++/*
++ * Determine the number of delay elements to calculate timing delays when
++ * the DLL is not able to be locked.  The DLL should always lock at
++ * 250MHz so we count the number of delay elements within the clock
++ * period.  If for some reason there is no lock then we return a default
++ * value.
++ *
++ * The delay element value should only be used when cp_dll_bypass_mode=1,
++ * otherwise units of 1/256 clock period are used.
++ */
++static int sdhci_cdns_sd6_get_delay_element(struct sdhci_host *host)
++{
++	struct sdhci_cdns_priv *priv = sdhci_cdns_priv(host);
++	struct sdhci_cdns_sd6_phy *phy = priv->phy;
++	int timeout_counter = 1000;
++	u32 delay_element = 0xff;
++	enum sdhci_cdns_sd6_phy_lock_mode lock_mode =
++		SDHCI_CDNS_SD6_PHY_LOCK_MODE_UNITIALIZED;
++	bool locked = false;
++	u32 reg = 0;
++	u8 dll_lock_value = 0xff;
++
++	phy->settings.cp_dll_bypass_mode = 0;
++
++	/* Setup HS400 @250MHz regs; sample DLL lock value */
++	sdhci_cdns_sd6_write_phy_reg(priv, SDHCI_CDNS_SD6_PHY_DQS_TIMING,
++				     0x780000);
++	sdhci_cdns_sd6_write_phy_reg(priv, SDHCI_CDNS_SD6_PHY_GATE_LPBK,
++				     0x81a00040);
++	sdhci_cdns_sd6_write_phy_reg(priv, SDHCI_CDNS_SD6_PHY_DLL_MASTER,
++				     0x200004);
++	sdhci_cdns_sd6_write_phy_reg(priv, SDHCI_CDNS_SD6_PHY_DLL_SLAVE,
++				     0x404000);
++	sdhci_cdns_sd6_write_phy_reg(priv, SDHCI_CDNS_SD6_PHY_CTRL, 0x4000);
++	sdhci_cdns_sd6_write_phy_reg(priv, SDHCI_CDNS_SD6_PHY_DQ_TIMING, 0x1);
++
++	/* turn on internal clock */
++	reg = sdhci_cdns_sd6_readw(host, SDHCI_CLOCK_CONTROL);
++	reg |= SDHCI_CLOCK_INT_EN;
++	sdhci_cdns_sd6_writew(host, reg, SDHCI_CLOCK_CONTROL);
++	/* wait for it to stabilize */
++	do {
++		reg = sdhci_cdns_sd6_readw(host, SDHCI_CLOCK_CONTROL);
++		udelay(1);
++	} while (!(reg & SDHCI_CLOCK_INT_STABLE) && (timeout_counter-- > 0));
++
++	if (!timeout_counter) {	/* should never happen */
++		pr_err("SDHCI internal clock unstable\n");
++		return -1;
++	}
++	reg = sdhci_cdns_sd6_readw(host, SDHCI_CLOCK_CONTROL);
++	reg &= ~0xffc0;
++	reg |= 0x100;	/* Set SDCFSL clock divider to 1 */
++	sdhci_cdns_sd6_writew(host, reg, SDHCI_CLOCK_CONTROL);
++
++	/* 8-bit burst, 4 transfers */
++	writel(0x30004, priv->hrs_addr + SDHCI_CDNS_HRS02);
++	/* HS400 mode */
++	writel(SDHCI_CDNS_HRS06_MODE_MMC_HS400,
++	       priv->hrs_addr + SDHCI_CDNS_HRS06);
++
++	/* Reset PHY */
++	writel(0xf1c00003, priv->hrs_addr + SDHCI_CDNS_HRS09);
++	/* Wait for init to complete */
++	do {
++		reg = readl(priv->hrs_addr + SDHCI_CDNS_HRS09);
++	} while (!(reg & SDHCI_CDNS_HRS09_PHY_INIT_COMPLETE));
++
++	mdelay(1);
++	if (sdhci_cdns_sd6_get_dll_parameters(priv, &lock_mode, &locked,
++					      &dll_lock_value)) {
++		pr_err("%s: Error getting DLL parameters\n", __func__);
++		return -1;
++	}
++
++	if (locked) {
++		if (lock_mode == SDHCI_CDNS_SD6_PHY_LOCK_MODE_FULL_CLK) {
++			delay_element = DIV_ROUND_UP(4000, dll_lock_value + 1);
++			tune_val_step = SDHCI_CDNS_TUNE_STEP;
++		} else if (lock_mode == SDHCI_CDNS_SD6_PHY_LOCK_MODE_HALF_CLK) {
++			delay_element = DIV_ROUND_UP(2000, dll_lock_value + 1);
++			tune_val_step = SDHCI_CDNS_TUNE_STEP / 2;
++		} else {
++			delay_element = SDHCI_CDNS_SD6_DEFAULT_DELAY_ELEMENT;
++			tune_val_step = SDHCI_CDNS_TUNE_STEP;
++			phy->settings.cp_dll_bypass_mode = 1;
++		}
++	} else {
++		delay_element = SDHCI_CDNS_SD6_DEFAULT_DELAY_ELEMENT;
++		tune_val_step = SDHCI_CDNS_TUNE_STEP;
++		phy->settings.cp_dll_bypass_mode = 1;
++	}
++	return delay_element;
++}
++
++static int sdhci_cdns_sd6_get_delay_params(struct device *dev,
++					   struct sdhci_cdns_priv *priv)
++{
++	struct sdhci_cdns_sd6_phy *phy = priv->phy;
++	int ret;
++
++	ret = device_property_read_u32(dev, "cdns,read_dqs_cmd_delay",
++				       &phy->settings.cp_read_dqs_cmd_delay);
++	if (ret)
++		phy->settings.cp_read_dqs_cmd_delay = DEFAULT_CMD_DELAY;
++
++	ret = device_property_read_u32(dev, "cdns,read_dqs_delay",
++				       &phy->settings.cp_read_dqs_delay);
++	if (ret)
++		phy->settings.cp_read_dqs_delay = DEFAULT_CMD_DELAY;
++
++	ret = device_property_read_u32(dev, "cdns,read_dqs_cmd_delay_hs400",
++				       &read_dqs_cmd_delay_hs400);
++	DEBUG_DRV("read_dqs_cmd_delay_hs400 %d\n", read_dqs_cmd_delay_hs400);
++	if (ret)
++		read_dqs_cmd_delay_hs400 = DEFAULT_READ_DQS_CMD_DELAY;
++
++	ret = device_property_read_u32(dev, "cdns,clk_wrdqs_delay_hs400",
++				       &clk_wrdqs_delay_hs400);
++	DEBUG_DRV("clk_wrdqs_delay_hs400 %d\n", clk_wrdqs_delay_hs400);
++	if (ret)
++		clk_wrdqs_delay_hs400 = DEFAULT_CLK_WRDQS_DELAY;
++
++	ret = device_property_read_u32(dev, "cdns,clk_wr_delay_hs400",
++				       &clk_wr_delay_hs400);
++	DEBUG_DRV("clk_wr_delay_hs400 %d\n", clk_wr_delay_hs400);
++	if (ret)
++		clk_wr_delay_hs400 = DEFAULT_CLK_WR_DELAY;
++
++	ret = device_property_read_u32(dev, "cdns,read_dqs_delay_hs400",
++				       &read_dqs_delay_hs400);
++	DEBUG_DRV("read_dqs_delay_hs400 %d\n", read_dqs_delay_hs400);
++	if (ret)
++		read_dqs_delay_hs400 = DEFAULT_READ_DQS_DELAY;
++
++	ret = device_property_read_u32(dev, "cdns,tune_val_start",
++				       &tune_val_start);
++	if (ret)
++		tune_val_start = SDHCI_CDNS_TUNE_START;
++
++	ret = device_property_read_u32(dev, "cdns,tune_val_step",
++				       &tune_val_step);
++	if (ret)
++		tune_val_step = SDHCI_CDNS_TUNE_STEP;
++
++	ret = device_property_read_u32(dev, "cdns,max_tune_iter",
++				       &max_tune_iter);
++	if (ret)
++		max_tune_iter = SDHCI_CDNS_TUNE_ITERATIONS;
++
++	/*
++	 * Device tree contains values for the tuning parameters
++	 * Per JESD84-B51, a valid 8-bit tune range satisfies:
++	 *     'tune_start_value + (tune_step * tune_iterations) <= 256'
++	 * If the DT-populated values cross 256, then these values may be
++	 * re-adjusted to default values, accordingly.
++	 */
++	pr_info("%s: Get Tuning params: Start[%d], Step[%d], Iterations[%d].\n",
++		__func__,  tune_val_start, tune_val_step, max_tune_iter);
++	if (WARN_ON((tune_val_start + (max_tune_iter * tune_val_step)) >
++		    SDHCI_CDNS_TUNE_MAX_VALUE)) {
++		tune_val_start = SDHCI_CDNS_TUNE_START;
++		tune_val_step = SDHCI_CDNS_TUNE_STEP;
++		max_tune_iter = SDHCI_CDNS_TUNE_ITERATIONS;
++		pr_info("%s: EMMC tuning params out-of-range; check device tree\n",
++			__func__);
++	}
++	pr_info("%s: Selected Tuning params: Start[%d], Step[%d], Iterations[%d].\n",
++		__func__,  tune_val_start, tune_val_step, max_tune_iter);
++
++	read_dqs_cmd_delay = phy->settings.cp_read_dqs_cmd_delay;
++	clk_wrdqs_delay = phy->settings.cp_clk_wrdqs_delay;
++	clk_wr_delay = phy->settings.cp_clk_wr_delay;
++	read_dqs_delay = phy->settings.cp_read_dqs_delay;
++	return 0;
++}
++
++static int sdhci_cdns_sd6_phy_init(struct sdhci_cdns_priv *priv)
++{
++	int ret;
++	u32 reg;
++	struct sdhci_cdns_sd6_phy *phy = priv->phy;
++
++	sdhci_cdns_sd6_dll_reset(priv, true);
++
++	reg = sdhci_cdns_sd6_read_phy_reg(priv, SDHCI_CDNS_SD6_PHY_DQS_TIMING);
++	reg &= ~SDHCI_CDNS_SD6_PHY_DQS_TIMING_USE_EXT_LPBK_DQS;
++	reg &= ~SDHCI_CDNS_SD6_PHY_DQS_TIMING_USE_LPBK_DQS;
++	reg &= ~SDHCI_CDNS_SD6_PHY_DQS_TIMING_USE_PHONY_DQS;
++	reg &= ~SDHCI_CDNS_SD6_PHY_DQS_TIMING_USE_PHONY_DQS_CMD;
++	reg |= FIELD_PREP(SDHCI_CDNS_SD6_PHY_DQS_TIMING_USE_EXT_LPBK_DQS,
++			phy->settings.cp_use_ext_lpbk_dqs);
++	reg |= FIELD_PREP(SDHCI_CDNS_SD6_PHY_DQS_TIMING_USE_LPBK_DQS,
++			phy->settings.cp_use_lpbk_dqs);
++	reg |= FIELD_PREP(SDHCI_CDNS_SD6_PHY_DQS_TIMING_USE_PHONY_DQS,
++			  phy->settings.cp_use_phony_dqs);
++	reg |= FIELD_PREP(SDHCI_CDNS_SD6_PHY_DQS_TIMING_USE_PHONY_DQS_CMD,
++			  phy->settings.cp_use_phony_dqs_cmd);
++	sdhci_cdns_sd6_write_phy_reg(priv, SDHCI_CDNS_SD6_PHY_DQS_TIMING, reg);
++
++	reg = sdhci_cdns_sd6_read_phy_reg(priv, SDHCI_CDNS_SD6_PHY_GATE_LPBK);
++	reg &= ~SDHCI_CDNS_SD6_PHY_GATE_LPBK_SYNC_METHOD;
++	reg &= ~SDHCI_CDNS_SD6_PHY_GATE_LPBK_SW_HALF_CYCLE_SHIFT;
++	reg &= ~SDHCI_CDNS_SD6_PHY_GATE_LPBK_RD_DEL_SEL;
++	reg &= ~SDHCI_CDNS_SD6_PHY_GATE_LPBK_GATE_CFG_ALWAYS_ON;
++	reg |= FIELD_PREP(SDHCI_CDNS_SD6_PHY_GATE_LPBK_SYNC_METHOD,
++			phy->settings.cp_sync_method);
++	reg |= FIELD_PREP(SDHCI_CDNS_SD6_PHY_GATE_LPBK_SW_HALF_CYCLE_SHIFT,
++			phy->settings.cp_sw_half_cycle_shift);
++	reg |= FIELD_PREP(SDHCI_CDNS_SD6_PHY_GATE_LPBK_RD_DEL_SEL,
++			phy->settings.cp_rd_del_sel);
++	reg |= FIELD_PREP(SDHCI_CDNS_SD6_PHY_GATE_LPBK_GATE_CFG_ALWAYS_ON,
++			phy->settings.cp_gate_cfg_always_on);
++	sdhci_cdns_sd6_write_phy_reg(priv, SDHCI_CDNS_SD6_PHY_GATE_LPBK, reg);
++
++	reg = 0x0;
++	reg |= FIELD_PREP(SDHCI_CDNS_SD6_PHY_DLL_MASTER_BYPASS_MODE,
++			 phy->settings.cp_dll_bypass_mode);
++	reg |= FIELD_PREP(SDHCI_CDNS_SD6_PHY_DLL_MASTER_PHASE_DETECT_SEL, 2);
++	reg |= FIELD_PREP(SDHCI_CDNS_SD6_PHY_DLL_MASTER_DLL_LOCK_NUM, 0);
++	reg |= FIELD_PREP(SDHCI_CDNS_SD6_PHY_DLL_MASTER_DLL_START_POINT,
++			phy->settings.cp_dll_start_point);
++	sdhci_cdns_sd6_write_phy_reg(priv, SDHCI_CDNS_SD6_PHY_DLL_MASTER, reg);
++
++	reg = 0x0;
++	reg = FIELD_PREP(SDHCI_CDNS_SD6_PHY_DLL_SLAVE_READ_DQS_CMD_DELAY,
++			 phy->settings.cp_read_dqs_cmd_delay);
++	reg |= FIELD_PREP(SDHCI_CDNS_SD6_PHY_DLL_SLAVE_CLK_WRDQS_DELAY,
++			  phy->settings.cp_clk_wrdqs_delay);
++	reg |= FIELD_PREP(SDHCI_CDNS_SD6_PHY_DLL_SLAVE_CLK_WR_DELAY,
++			  phy->settings.cp_clk_wr_delay);
++	reg |= FIELD_PREP(SDHCI_CDNS_SD6_PHY_DLL_SLAVE_READ_DQS_DELAY,
++			  phy->settings.cp_read_dqs_delay);
++	sdhci_cdns_sd6_write_phy_reg(priv, SDHCI_CDNS_SD6_PHY_DLL_SLAVE, reg);
++
++	reg = sdhci_cdns_sd6_read_phy_reg(priv, SDHCI_CDNS_SD6_PHY_CTRL);
++	reg &= ~SDHCI_CDNS_SD6_PHY_CTRL_PHONY_DQS_TIMING;
++	sdhci_cdns_sd6_write_phy_reg(priv, SDHCI_CDNS_SD6_PHY_CTRL, reg);
++
++	reg = sdhci_cdns_sd6_read_phy_reg(priv, SDHCI_CDNS_SD6_PHY_GPIO_CTRL0);
++	reg &= ~0x77;
++	reg |= SDHCI_CDNS_SD6_PHY_GPIO_CTRL0_DRV_OVR_EN |
++		SDHCI_CDNS_SD6_PHY_GPIO_CTRL0_SLEW_OVR_EN;
++	reg |= FIELD_PREP(SDHCI_CDNS_SD6_PHY_GPIO_CTRL0_DRV,
++		phy->settings.drive);
++	reg |= FIELD_PREP(SDHCI_CDNS_SD6_PHY_GPIO_CTRL0_SLEW,
++		phy->settings.slew);
++	sdhci_cdns_sd6_write_phy_reg(priv, SDHCI_CDNS_SD6_PHY_GPIO_CTRL0, reg);
++
++	ret = sdhci_cdns_sd6_dll_reset(priv, false);
++	if (ret)
++		return ret;
++
++	reg = sdhci_cdns_sd6_read_phy_reg(priv, SDHCI_CDNS_SD6_PHY_DQ_TIMING);
++	reg &= ~SDHCI_CDNS_SD6_PHY_DQ_TIMING_IO_MASK_ALWAYS_ON;
++	reg &= ~SDHCI_CDNS_SD6_PHY_DQ_TIMING_IO_MASK_END;
++	reg &= ~SDHCI_CDNS_SD6_PHY_DQ_TIMING_IO_MASK_START;
++	reg &= ~SDHCI_CDNS_SD6_PHY_DQ_TIMING_DATA_SELECT_OE_END;
++	reg |= FIELD_PREP(SDHCI_CDNS_SD6_PHY_DQ_TIMING_IO_MASK_ALWAYS_ON,
++			phy->settings.cp_io_mask_always_on);
++	reg |= FIELD_PREP(SDHCI_CDNS_SD6_PHY_DQ_TIMING_IO_MASK_END,
++			  phy->settings.cp_io_mask_end);
++	reg |= FIELD_PREP(SDHCI_CDNS_SD6_PHY_DQ_TIMING_IO_MASK_START,
++			  phy->settings.cp_io_mask_start);
++	reg |= FIELD_PREP(SDHCI_CDNS_SD6_PHY_DQ_TIMING_DATA_SELECT_OE_END,
++			phy->settings.cp_data_select_oe_end);
++	sdhci_cdns_sd6_write_phy_reg(priv, SDHCI_CDNS_SD6_PHY_DQ_TIMING, reg);
++
++	reg = readl(priv->hrs_addr + SDHCI_CDNS_HRS09);
++	if (phy->settings.sdhc_extended_wr_mode)
++		reg |= SDHCI_CDNS_HRS09_EXTENDED_WR_MODE;
++	else
++		reg &= ~SDHCI_CDNS_HRS09_EXTENDED_WR_MODE;
++
++	if (phy->settings.sdhc_extended_rd_mode)
++		reg |= SDHCI_CDNS_HRS09_EXTENDED_RD_MODE;
++	else
++		reg &= ~SDHCI_CDNS_HRS09_EXTENDED_RD_MODE;
++
++	if (phy->settings.sdhc_rddata_en)
++		reg |= SDHCI_CDNS_HRS09_RDDATA_EN;
++	else
++		reg &= ~SDHCI_CDNS_HRS09_RDDATA_EN;
++
++	if (phy->settings.sdhc_rdcmd_en)
++		reg |= SDHCI_CDNS_HRS09_RDCMD_EN;
++	else
++		reg &= ~SDHCI_CDNS_HRS09_RDCMD_EN;
++
++	writel(reg, priv->hrs_addr + SDHCI_CDNS_HRS09);
++
++	writel(0x30004, priv->hrs_addr + SDHCI_CDNS_HRS02);
++
++	reg = 0x0;
++	reg = FIELD_PREP(SDHCI_CDNS_HRS10_HCSDCLKADJ,
++			 phy->settings.sdhc_hcsdclkadj);
++	writel(reg, priv->hrs_addr + SDHCI_CDNS_HRS10);
++
++	if (phy->mode != MMC_TIMING_MMC_HS &&
++	    phy->mode != MMC_TIMING_MMC_DDR52) {
++		reg = 0x0;
++		reg = FIELD_PREP(SDHCI_CDNS_HRS16_WRDATA1_SDCLK_DLY,
++				 phy->settings.sdhc_wrdata1_sdclk_dly);
++		reg |= FIELD_PREP(SDHCI_CDNS_HRS16_WRDATA0_SDCLK_DLY,
++				  phy->settings.sdhc_wrdata0_sdclk_dly);
++		reg |= FIELD_PREP(SDHCI_CDNS_HRS16_WRCMD1_SDCLK_DLY,
++				  phy->settings.sdhc_wrcmd1_sdclk_dly);
++		reg |= FIELD_PREP(SDHCI_CDNS_HRS16_WRCMD0_SDCLK_DLY,
++				  phy->settings.sdhc_wrcmd0_sdclk_dly);
++		reg |= FIELD_PREP(SDHCI_CDNS_HRS16_WRDATA1_DLY,
++				  phy->settings.sdhc_wrdata1_dly);
++		reg |= FIELD_PREP(SDHCI_CDNS_HRS16_WRDATA0_DLY,
++				  phy->settings.sdhc_wrdata0_dly);
++		reg |= FIELD_PREP(SDHCI_CDNS_HRS16_WRCMD1_DLY,
++				  phy->settings.sdhc_wrcmd1_dly);
++		reg |= FIELD_PREP(SDHCI_CDNS_HRS16_WRCMD0_DLY,
++				  phy->settings.sdhc_wrcmd0_dly);
++	} else {
++		reg = 0x202;
++	}
++
++	writel(reg, priv->hrs_addr + SDHCI_CDNS_HRS16);
++
++	reg = 0x0;
++	reg = FIELD_PREP(SDHCI_CDNS_HRS07_RW_COMPENSATE,
++			 phy->settings.sdhc_rw_compensate);
++	reg |= FIELD_PREP(SDHCI_CDNS_HRS07_IDELAY_VAL,
++			 phy->settings.sdhc_idelay_val);
++	writel(reg, priv->hrs_addr + SDHCI_CDNS_HRS07);
++	return 0;
++}
++
++static int sdhci_cdns_sd6_set_tune_val(struct sdhci_host *host,
++				       unsigned int val)
++{
++	struct sdhci_cdns_priv *priv = sdhci_cdns_priv(host);
++	struct sdhci_cdns_sd6_phy *phy = priv->phy;
++
++	phy->settings.hs200_tune_val = val;
++	phy->settings.cp_read_dqs_cmd_delay = read_dqs_cmd_delay;
++	phy->settings.cp_read_dqs_delay = val;
++
++	return sdhci_cdns_sd6_phy_init(priv);
++}
++
++static unsigned int sdhci_cdns_get_timeout_clock(struct sdhci_host *host)
++{
++	/*
++	 * Cadence's spec says the Timeout Clock Frequency is the same as the
++	 * Base Clock Frequency.
++	 */
++	return host->max_clk;
++}
++
++static unsigned int sdhci_cdns_get_max_clock(struct sdhci_host *host)
++{
++	return SDMCLK_MAX_FREQ;
++}
++
++static void sdhci_cdns_set_emmc_mode(struct sdhci_cdns_priv *priv, u32 mode)
++{
++	u32 tmp;
++
++	/* The speed mode for eMMC is selected by HRS06 register */
++	tmp = readl(priv->hrs_addr + SDHCI_CDNS_HRS06);
++	tmp &= ~SDHCI_CDNS_HRS06_MODE;
++	tmp |= FIELD_PREP(SDHCI_CDNS_HRS06_MODE, mode);
++	priv->priv_writel(priv, tmp, priv->hrs_addr + SDHCI_CDNS_HRS06);
++}
++
++static u32 sdhci_cdns_get_emmc_mode(struct sdhci_cdns_priv *priv)
++{
++	u32 tmp;
++
++	tmp = readl(priv->hrs_addr + SDHCI_CDNS_HRS06);
++	return FIELD_GET(SDHCI_CDNS_HRS06_MODE, tmp);
++}
++
++static void sdhci_cdns_set_uhs_signaling(struct sdhci_host *host,
++					 unsigned int timing)
++{
++	struct sdhci_cdns_priv *priv = sdhci_cdns_priv(host);
++	u32 mode;
++
++	switch (timing) {
++	case MMC_TIMING_MMC_HS:
++		mode = SDHCI_CDNS_HRS06_MODE_MMC_SDR;
++		break;
++	case MMC_TIMING_MMC_DDR52:
++		mode = SDHCI_CDNS_HRS06_MODE_MMC_DDR;
++		break;
++	case MMC_TIMING_MMC_HS200:
++		mode = SDHCI_CDNS_HRS06_MODE_MMC_HS200;
++		break;
++	case MMC_TIMING_MMC_HS400:
++		if (priv->enhanced_strobe)
++			mode = SDHCI_CDNS_HRS06_MODE_MMC_HS400ES;
++		else
++			mode = SDHCI_CDNS_HRS06_MODE_MMC_HS400;
++		break;
++	case MMC_TIMING_SD_HS:
++		mode = SDHCI_CDNS_HRS06_MODE_SD;
++		break;
++	default:
++		mode = SDHCI_CDNS_HRS06_MODE_LEGACY;
++		break;
++	}
++
++	pr_debug("%s mode %d timing %d\n", __func__, mode, timing);
++	sdhci_cdns_set_emmc_mode(priv, mode);
++
++	/* For SD, fall back to the default handler */
++	if (mode == SDHCI_CDNS_HRS06_MODE_SD)
++		sdhci_set_uhs_signaling(host, timing);
++}
++
++static int sdhci_cdns_sd6_phy_update_timings(struct sdhci_host *host)
++{
++	struct sdhci_cdns_priv *priv = sdhci_cdns_priv(host);
++	struct sdhci_cdns_sd6_phy *phy = priv->phy;
++	int t_sdmclk = phy->t_sdmclk;
++	int mode;
++
++	mode = sdhci_cdns_sd6_get_mode(host, host->mmc->ios.timing);
++	/* initialize input */
++	init_timings[mode](&phy->t, phy->t_sdclk);
++
++	phy->mode = host->mmc->ios.timing;
++	phy->strobe_dat = false;
++	phy->strobe_cmd = false;
++
++	switch (phy->mode) {
++	case MMC_TIMING_UHS_SDR104:
++		phy->tune_cmd = true;
++		phy->tune_dat = true;
++		break;
++	case MMC_TIMING_UHS_DDR50:
++		phy->ddr = true;
++		break;
++	case MMC_TIMING_MMC_DDR52:
++		phy->ddr = true;
++		break;
++	case MMC_TIMING_MMC_HS200:
++		phy->tune_dat = true;
++		phy->tune_cmd = true;
++		break;
++	case MMC_TIMING_MMC_HS400:
++		phy->tune_cmd = true;
++		phy->ddr = true;
++		phy->strobe_dat = true;
++		if (priv->enhanced_strobe)
++			phy->strobe_cmd = true;
++		break;
++	}
++
++	phy->d.phy_sdclk_delay = 2 * t_sdmclk;
++	phy->d.phy_cmd_o_delay = 2 * t_sdmclk + t_sdmclk / 2;
++	phy->d.phy_dat_o_delay = 2 * t_sdmclk + t_sdmclk / 2;
++
++	if (phy->t_sdclk == phy->t_sdmclk) {
++		phy->settings.sdhc_extended_wr_mode = 0;
++		phy->settings.sdhc_extended_rd_mode = 0;
++	} else {
++		phy->settings.sdhc_extended_wr_mode = 1;
++		phy->settings.sdhc_extended_rd_mode = 1;
++	}
++
++	phy->settings.cp_gate_cfg_always_on = 1;
++
++	sdhci_cdns_sd6_phy_configure_dll(priv);
++
++	sdhci_cdns_sd6_phy_calc_settings(phy);
++
++	return 0;
++}
++
++static u32 sdhci_cdns_sd6_get_mode(struct sdhci_host *host,
++				   unsigned int timing)
++{
++	struct sdhci_cdns_priv *priv = sdhci_cdns_priv(host);
++	u32 mode;
++
++	switch (timing) {
++	case MMC_TIMING_MMC_HS:
++		mode = SDHCI_CDNS_HRS06_MODE_MMC_SDR;
++		break;
++	case MMC_TIMING_MMC_DDR52:
++		mode = SDHCI_CDNS_HRS06_MODE_MMC_DDR;
++		break;
++	case MMC_TIMING_MMC_HS200:
++		mode = SDHCI_CDNS_HRS06_MODE_MMC_HS200;
++		break;
++	case MMC_TIMING_MMC_HS400:
++		if (priv->enhanced_strobe)
++			mode = SDHCI_CDNS_HRS06_MODE_MMC_HS400ES;
++		else
++			mode = SDHCI_CDNS_HRS06_MODE_MMC_HS400;
++		break;
++	case MMC_TIMING_SD_HS:
++		mode = SDHCI_CDNS_HRS06_MODE_SD;
++		break;
++	default:
++		mode = SDHCI_CDNS_HRS06_MODE_MMC_SDR;
++		break;
++	}
++
++	return mode;
+ }
+ 
+-static int sdhci_cdns_write_phy_reg(struct sdhci_cdns_priv *priv,
+-				    u8 addr, u8 data)
++static u32 sdhci_cdns_sd6_irq(struct sdhci_host *host, u32 intmask)
+ {
+-	void __iomem *reg = priv->hrs_addr + SDHCI_CDNS_HRS04;
+-	u32 tmp;
+-	int ret;
++	struct sdhci_cdns_priv *priv;
++	u64 reg;
+ 
+-	ret = readl_poll_timeout(reg, tmp, !(tmp & SDHCI_CDNS_HRS04_ACK),
+-				 0, 10);
+-	if (ret)
+-		return ret;
++	/* If errata workaround is not required, return */
++	if (!cn10k_irq_workaround)
++		return intmask;
+ 
+-	tmp = FIELD_PREP(SDHCI_CDNS_HRS04_WDATA, data) |
+-	      FIELD_PREP(SDHCI_CDNS_HRS04_ADDR, addr);
+-	priv->priv_writel(priv, tmp, reg);
++	priv = sdhci_cdns_priv(host);
++	reg = readq(priv->hrs_addr + CN10K_MSIX_INTR);
+ 
+-	tmp |= SDHCI_CDNS_HRS04_WR;
+-	priv->priv_writel(priv, tmp, reg);
++	if (intmask)
++		sdhci_cdns_sd6_writel(host, intmask, SDHCI_INT_STATUS);
+ 
+-	ret = readl_poll_timeout(reg, tmp, tmp & SDHCI_CDNS_HRS04_ACK, 0, 10);
+-	if (ret)
+-		return ret;
++	writeq(reg, priv->hrs_addr + CN10K_MSIX_INTR);
++	reg = readq(priv->hrs_addr + CN10K_MSIX_INTR);
+ 
+-	tmp &= ~SDHCI_CDNS_HRS04_WR;
+-	priv->priv_writel(priv, tmp, reg);
++	return intmask;
++}
+ 
+-	ret = readl_poll_timeout(reg, tmp, !(tmp & SDHCI_CDNS_HRS04_ACK),
+-				 0, 10);
++static void sdhci_cdns_sd6_set_uhs_signaling(struct sdhci_host *host,
++					     unsigned int timing)
++{
++	struct sdhci_cdns_priv *priv = sdhci_cdns_priv(host);
++	struct sdhci_cdns_sd6_phy *phy = priv->phy;
+ 
+-	return ret;
++	sdhci_cdns_set_uhs_signaling(host, timing);
++
++	if ((phy->mode == -1) || (phy->t_sdclk == -1))
++		return;
++
++	if (sdhci_cdns_sd6_phy_update_timings(host))
++		pr_debug("%s: update timings failed\n", __func__);
++
++	if (sdhci_cdns_sd6_phy_init(priv))
++		pr_debug("%s: phy init failed\n", __func__);
+ }
+ 
+-static unsigned int sdhci_cdns_phy_param_count(struct device_node *np)
++static void sdhci_cdns_sd6_set_clock(struct sdhci_host *host,
++				     unsigned int clock)
+ {
+-	unsigned int count = 0;
+-	int i;
++	struct sdhci_cdns_priv *priv = sdhci_cdns_priv(host);
++	struct sdhci_cdns_sd6_phy *phy = priv->phy;
+ 
+-	for (i = 0; i < ARRAY_SIZE(sdhci_cdns_phy_cfgs); i++)
+-		if (of_property_read_bool(np, sdhci_cdns_phy_cfgs[i].property))
+-			count++;
++	if (clock == 0)
++		return sdhci_set_clock(host, clock);
+ 
+-	return count;
++	phy->t_sdclk = DIV_ROUND_DOWN_ULL(1e12, clock);
++
++	pr_debug("%s %d %d\n", __func__, phy->mode, clock);
++
++	if (sdhci_cdns_sd6_phy_update_timings(host))
++		pr_debug("%s: update timings failed\n", __func__);
++
++	if (sdhci_cdns_sd6_phy_init(priv))
++		pr_debug("%s: phy init failed\n", __func__);
++
++	sdhci_set_clock(host, clock);
++
++#ifdef CONFIG_MMC_SDHCI_CADENCE_DEBUG
++	sdhci_cdns_sd6_dump(priv);
++#endif
+ }
+ 
+-static void sdhci_cdns_phy_param_parse(struct device_node *np,
+-				       struct sdhci_cdns_priv *priv)
++static int sdhci_cdns_sd6_phy_probe(struct platform_device *pdev)
+ {
+-	struct sdhci_cdns_phy_param *p = priv->phy_params;
++	struct device *dev = &pdev->dev;
++	struct sdhci_cdns_sd6_phy *phy;
++	struct sdhci_host *host = platform_get_drvdata(pdev);
++	struct sdhci_cdns_priv *priv = sdhci_cdns_priv(host);
+ 	u32 val;
+-	int ret, i;
++	struct clk *clk;
++	int ret;
++	const char *mode_name;
+ 
+-	for (i = 0; i < ARRAY_SIZE(sdhci_cdns_phy_cfgs); i++) {
+-		ret = of_property_read_u32(np, sdhci_cdns_phy_cfgs[i].property,
+-					   &val);
+-		if (ret)
+-			continue;
++	phy = devm_kzalloc(dev, sizeof(*phy), GFP_KERNEL);
++	if (!phy)
++		return -ENOMEM;
+ 
+-		p->addr = sdhci_cdns_phy_cfgs[i].addr;
+-		p->data = val;
+-		p++;
+-	}
+-}
++	priv->phy = phy;
+ 
+-static int sdhci_cdns_phy_init(struct sdhci_cdns_priv *priv)
+-{
+-	int ret, i;
++	if (!has_acpi_companion(dev)) {
++		clk = devm_clk_get(dev, "sdmclk");
++		if (IS_ERR(clk)) {
++			dev_err(dev, "sdmclk get error\n");
++			return PTR_ERR(clk);
++		}
+ 
+-	for (i = 0; i < priv->nr_phy_params; i++) {
+-		ret = sdhci_cdns_write_phy_reg(priv, priv->phy_params[i].addr,
+-					       priv->phy_params[i].data);
+-		if (ret)
+-			return ret;
++		val = clk_get_rate(clk);
++	} else {
++		if (device_property_read_u32(dev, "clock-frequency", &val))
++			// Property not found, but it's mandatory for ACPI case
++			return -ENODEV;
+ 	}
++	phy->t_sdmclk = DIV_ROUND_DOWN_ULL(1e12, val);
+ 
+-	return 0;
+-}
++	ret = device_property_read_u32(dev, "cdns,host_slew",
++				       &phy->settings.slew);
++	if (ret)
++		phy->settings.slew = 3;
+ 
+-static void *sdhci_cdns_priv(struct sdhci_host *host)
+-{
+-	struct sdhci_pltfm_host *pltfm_host = sdhci_priv(host);
++	ret = device_property_read_u32(dev, "cdns,host_drive",
++				       &phy->settings.drive);
++	if (ret)
++		phy->settings.drive = 2;
+ 
+-	return sdhci_pltfm_priv(pltfm_host);
+-}
++	ret = device_property_read_u32(dev, "cdns,iocell_input_delay",
++				       &phy->d.iocell_input_delay);
++	if (ret)
++		phy->d.iocell_input_delay = 2500;
+ 
+-static unsigned int sdhci_cdns_get_timeout_clock(struct sdhci_host *host)
+-{
+-	/*
+-	 * Cadence's spec says the Timeout Clock Frequency is the same as the
+-	 * Base Clock Frequency.
+-	 */
+-	return host->max_clk;
+-}
++	ret = device_property_read_u32(dev, "cdns,iocell_output_delay",
++				       &phy->d.iocell_output_delay);
++	if (ret)
++		phy->d.iocell_output_delay = 2500;
+ 
+-static void sdhci_cdns_set_emmc_mode(struct sdhci_cdns_priv *priv, u32 mode)
+-{
+-	u32 tmp;
++	ret = device_property_read_u32(dev, "cdns,delay_element",
++				       &phy->d.delay_element);
++	if (ret) {
++		ret = sdhci_cdns_sd6_get_delay_element(host);
++		if (ret < 0)
++			return ret;
++		phy->d.delay_element = ret;
++	}
+ 
+-	/* The speed mode for eMMC is selected by HRS06 register */
+-	tmp = readl(priv->hrs_addr + SDHCI_CDNS_HRS06);
+-	tmp &= ~SDHCI_CDNS_HRS06_MODE;
+-	tmp |= FIELD_PREP(SDHCI_CDNS_HRS06_MODE, mode);
+-	priv->priv_writel(priv, tmp, priv->hrs_addr + SDHCI_CDNS_HRS06);
+-}
++	ret = device_property_read_string(dev, "cdns,mode", &mode_name);
++	if (!ret) {
++		if (!strcmp("emmc_sdr", mode_name))
++			phy->mode = MMC_TIMING_MMC_HS;
++		else if (!strcmp("emmc_ddr", mode_name))
++			phy->mode = MMC_TIMING_MMC_DDR52;
++		else if (!strcmp("emmc_hs200", mode_name))
++			phy->mode = MMC_TIMING_MMC_HS200;
++		else if (!strcmp("emmc_hs400", mode_name))
++			phy->mode = MMC_TIMING_MMC_HS400;
++		else if (!strcmp("sd_hs", mode_name))
++			phy->mode = MMC_TIMING_SD_HS;
++		else
++			phy->mode = MMC_TIMING_MMC_HS;
++	} else {
++		phy->mode = MMC_TIMING_MMC_HS;
++	}
+ 
+-static u32 sdhci_cdns_get_emmc_mode(struct sdhci_cdns_priv *priv)
+-{
+-	u32 tmp;
++	phy->d.delay_element_org = phy->d.delay_element;
++	phy->d.iocell_input_delay = 650;
++	phy->d.iocell_output_delay = 1800;
+ 
+-	tmp = readl(priv->hrs_addr + SDHCI_CDNS_HRS06);
+-	return FIELD_GET(SDHCI_CDNS_HRS06_MODE, tmp);
++	switch (phy->mode) {
++	case MMC_TIMING_MMC_HS:
++		phy->t_sdclk =  10000;
++		break;
++	case MMC_TIMING_MMC_DDR52:
++		phy->t_sdclk = 10000;
++		break;
++	case MMC_TIMING_MMC_HS200:
++		phy->t_sdclk = 5000;
++		break;
++	case MMC_TIMING_MMC_HS400:
++		phy->t_sdclk = 5000;
++		break;
++	case MMC_TIMING_SD_HS:
++		phy->t_sdclk = 100000;
++		break;
++	default:
++		phy->t_sdclk = 10000;
++		break;
++	}
++
++	sdhci_cdns_sd6_get_delay_params(dev, priv);
++
++	sdhci_cdns_sd6_calc_phy(phy);
++	return 0;
+ }
+ 
+-static int sdhci_cdns_set_tune_val(struct sdhci_host *host, unsigned int val)
++static int sdhci_cdns_sd4_set_tune_val(struct sdhci_host *host,
++				       unsigned int val)
+ {
+ 	struct sdhci_cdns_priv *priv = sdhci_cdns_priv(host);
+ 	void __iomem *reg = priv->hrs_addr + SDHCI_CDNS_HRS06;
+@@ -251,16 +2004,57 @@ static int sdhci_cdns_set_tune_val(struct sdhci_host *host, unsigned int val)
+ 	return 0;
+ }
+ 
++/**
++ * sdhci_cdns_tune_blkgap() - tune multi-block read gap
++ * @mmc: MMC host
++ *
++ * Tune delay used in multi block read. To do so,
++ * try sending multi-block read command with incremented gap, unless
++ * it succeeds.
++ *
++ * Return: error code
++ */
++static int sdhci_cdns_tune_blkgap(struct mmc_host *mmc)
++{
++	struct sdhci_host *host = mmc_priv(mmc);
++	struct sdhci_pltfm_host *pltfm_host = sdhci_priv(host);
++	struct sdhci_cdns_priv *priv = sdhci_pltfm_priv(pltfm_host);
++	void __iomem *hrs37_reg = priv->hrs_addr + SDHCI_CDNS_HRS37;
++	void __iomem *hrs38_reg = priv->hrs_addr + SDHCI_CDNS_HRS38;
++	int ret;
++	u32 gap;
++
++	/* Currently only needed in HS200 mode */
++	if (host->timing != MMC_TIMING_MMC_HS200)
++		return 0;
++
++	writel(SDHCI_CDNS_HRS37_MODE_MMC_HS200, hrs37_reg);
++
++	for (gap = 0; gap <= SDHCI_CDNS_HRS38_BLKGAP_MAX; gap++) {
++		writel(gap, hrs38_reg);
++		ret = mmc_read_tuning(mmc, 512, 32);
++		if (!ret)
++			break;
++	}
++
++	dev_dbg(mmc_dev(mmc), "read block gap tune %s, gap %d\n",
++		ret ? "failed" : "OK", gap);
++	return ret;
++}
++
+ /*
+  * In SD mode, software must not use the hardware tuning and instead perform
+  * an almost identical procedure to eMMC.
+  */
+-static int sdhci_cdns_execute_tuning(struct sdhci_host *host, u32 opcode)
++static int sdhci_cdns_sd6_execute_tuning(struct sdhci_host *host, u32 opcode)
+ {
++	struct sdhci_cdns_priv *priv = sdhci_cdns_priv(host);
+ 	int cur_streak = 0;
+ 	int max_streak = 0;
+ 	int end_of_streak = 0;
+ 	int i;
++	int ret;
++	int midpoint, iter = 0;
+ 
+ 	/*
+ 	 * Do not execute tuning for UHS_SDR50 or UHS_DDR50.
+@@ -270,15 +2064,26 @@ static int sdhci_cdns_execute_tuning(struct sdhci_host *host, u32 opcode)
+ 	    host->timing != MMC_TIMING_UHS_SDR104)
+ 		return 0;
+ 
+-	for (i = 0; i < SDHCI_CDNS_MAX_TUNING_LOOP; i++) {
+-		if (sdhci_cdns_set_tune_val(host, i) ||
++	for (i = tune_val_start; iter < max_tune_iter;
++	     iter++, i += tune_val_step) {
++		if (priv->cdns_data->set_tune_val(host, i) ||
+ 		    mmc_send_tuning(host->mmc, opcode, NULL)) { /* bad */
+ 			cur_streak = 0;
+ 		} else { /* good */
++			int span_start;
+ 			cur_streak++;
+ 			if (cur_streak > max_streak) {
+ 				max_streak = cur_streak;
+ 				end_of_streak = i;
++				span_start = end_of_streak -
++					((cur_streak - 1) * tune_val_step);
++				pr_debug("%s (%d-%d = %d)", __func__,
++					 span_start, end_of_streak, cur_streak);
++			} else {
++				span_start = i - ((cur_streak - 1) *
++						      tune_val_step);
++
++				pr_debug("%s (%d-%d)", __func__, span_start, i);
+ 			}
+ 		}
+ 	}
+@@ -287,42 +2092,67 @@ static int sdhci_cdns_execute_tuning(struct sdhci_host *host, u32 opcode)
+ 		dev_err(mmc_dev(host->mmc), "no tuning point found\n");
+ 		return -EIO;
+ 	}
++	{
++		int span_start = end_of_streak -
++			((max_streak - 1) * tune_val_step);
++
++		pr_debug("max_streak: %d-%d", span_start, end_of_streak);
++	}
++
++	midpoint = end_of_streak - (((max_streak - 1) * tune_val_step) / 2);
++	pr_info("%s: Tuning Midpoint value = %d\n", __func__, midpoint);
++
++	ret = priv->cdns_data->set_tune_val(host, midpoint);
++	if (ret)
++		return ret;
++
++	return sdhci_cdns_tune_blkgap(host->mmc);
+ 
+-	return sdhci_cdns_set_tune_val(host, end_of_streak - max_streak / 2);
+ }
+ 
+-static void sdhci_cdns_set_uhs_signaling(struct sdhci_host *host,
+-					 unsigned int timing)
++/*
++ * In SD mode, software must not use the hardware tuning and instead perform
++ * an almost identical procedure to eMMC.
++ */
++static int sdhci_cdns_execute_tuning(struct sdhci_host *host, u32 opcode)
+ {
+-	struct sdhci_cdns_priv *priv = sdhci_cdns_priv(host);
+-	u32 mode;
++	int cur_streak = 0;
++	int max_streak = 0;
++	int end_of_streak = 0;
++	int i;
++	int ret;
+ 
+-	switch (timing) {
+-	case MMC_TIMING_MMC_HS:
+-		mode = SDHCI_CDNS_HRS06_MODE_MMC_SDR;
+-		break;
+-	case MMC_TIMING_MMC_DDR52:
+-		mode = SDHCI_CDNS_HRS06_MODE_MMC_DDR;
+-		break;
+-	case MMC_TIMING_MMC_HS200:
+-		mode = SDHCI_CDNS_HRS06_MODE_MMC_HS200;
+-		break;
+-	case MMC_TIMING_MMC_HS400:
+-		if (priv->enhanced_strobe)
+-			mode = SDHCI_CDNS_HRS06_MODE_MMC_HS400ES;
+-		else
+-			mode = SDHCI_CDNS_HRS06_MODE_MMC_HS400;
+-		break;
+-	default:
+-		mode = SDHCI_CDNS_HRS06_MODE_SD;
+-		break;
++	/*
++	 * Do not execute tuning for UHS_SDR50 or UHS_DDR50.
++	 * The delay is set by probe, based on the DT properties.
++	 */
++	if (host->timing != MMC_TIMING_MMC_HS200 &&
++	    host->timing != MMC_TIMING_UHS_SDR104)
++		return 0;
++
++	for (i = 0; i < SDHCI_CDNS_MAX_TUNING_LOOP; i++) {
++		if (sdhci_cdns_sd4_set_tune_val(host, i) ||
++		    mmc_send_tuning(host->mmc, opcode, NULL)) { /* bad */
++			cur_streak = 0;
++		} else { /* good */
++			cur_streak++;
++			if (cur_streak > max_streak) {
++				max_streak = cur_streak;
++				end_of_streak = i;
++			}
++		}
+ 	}
+ 
+-	sdhci_cdns_set_emmc_mode(priv, mode);
++	if (!max_streak) {
++		dev_err(mmc_dev(host->mmc), "no tuning point found\n");
++		return -EIO;
++	}
+ 
+-	/* For SD, fall back to the default handler */
+-	if (mode == SDHCI_CDNS_HRS06_MODE_SD)
+-		sdhci_set_uhs_signaling(host, timing);
++	ret = sdhci_cdns_sd4_set_tune_val(host, end_of_streak - max_streak / 2);
++	if (ret)
++		return ret;
++
++	return sdhci_cdns_tune_blkgap(host->mmc);
+ }
+ 
+ /* Elba control register bits [6:3] are byte-lane enables */
+@@ -410,7 +2240,7 @@ static int elba_drv_init(struct platform_device *pdev)
+ 	return 0;
+ }
+ 
+-static const struct sdhci_ops sdhci_cdns_ops = {
++static const struct sdhci_ops sdhci_cdns_sd4_ops = {
+ 	.set_clock = sdhci_set_clock,
+ 	.get_timeout_clock = sdhci_cdns_get_timeout_clock,
+ 	.set_bus_width = sdhci_set_bus_width,
+@@ -419,11 +2249,31 @@ static const struct sdhci_ops sdhci_cdns_ops = {
+ 	.set_uhs_signaling = sdhci_cdns_set_uhs_signaling,
+ };
+ 
++static const struct sdhci_ops sdhci_cdns_sd6_ops = {
++#ifdef CONFIG_MMC_SDHCI_IO_ACCESSORS
++	.read_l = sdhci_cdns_sd6_readl,
++	.write_l = sdhci_cdns_sd6_writel,
++	.read_w = sdhci_cdns_sd6_readw,
++	.write_w = sdhci_cdns_sd6_writew,
++	.read_b = sdhci_cdns_sd6_readb,
++	.write_b = sdhci_cdns_sd6_writeb,
++#endif
++	.get_max_clock = sdhci_cdns_get_max_clock,
++	.set_clock = sdhci_cdns_sd6_set_clock,
++	.get_timeout_clock = sdhci_cdns_get_timeout_clock,
++	.set_bus_width = sdhci_set_bus_width,
++	.reset = sdhci_reset,
++	.platform_execute_tuning = sdhci_cdns_sd6_execute_tuning,
++	.set_uhs_signaling = sdhci_cdns_sd6_set_uhs_signaling,
++	.irq = sdhci_cdns_sd6_irq,
++};
++
+ static const struct sdhci_cdns_drv_data sdhci_cdns_uniphier_drv_data = {
+ 	.pltfm_data = {
+-		.ops = &sdhci_cdns_ops,
++		.ops = &sdhci_cdns_sd4_ops,
+ 		.quirks2 = SDHCI_QUIRK2_PRESET_VALUE_BROKEN,
+ 	},
++	.cdns_data = NULL,
+ };
+ 
+ static const struct sdhci_cdns_drv_data sdhci_elba_drv_data = {
+@@ -431,12 +2281,32 @@ static const struct sdhci_cdns_drv_data sdhci_elba_drv_data = {
+ 	.pltfm_data = {
+ 		.ops = &sdhci_elba_ops,
+ 	},
++	.cdns_data = NULL,
++};
++
++static const struct sdhci_cdns_data sdhci_cdns_sd4_data = {
++	.phy_init = sdhci_cdns_sd4_phy_init,
++	.set_tune_val = sdhci_cdns_sd4_set_tune_val,
++};
++
++static const struct sdhci_cdns_data sdhci_cdns_sd6_data = {
++	.phy_init = sdhci_cdns_sd6_phy_init,
++	.set_tune_val = sdhci_cdns_sd6_set_tune_val,
++};
++
++static const struct sdhci_cdns_drv_data sdhci_cdns_sd4_drv_data = {
++	.pltfm_data = {
++		.ops = &sdhci_cdns_sd4_ops,
++	},
++	.cdns_data = &sdhci_cdns_sd4_data,
+ };
+ 
+-static const struct sdhci_cdns_drv_data sdhci_cdns_drv_data = {
++static const struct sdhci_cdns_drv_data sdhci_cdns_sd6_drv_data = {
++	.init = sdhci_cdns_sd6_phy_probe,
+ 	.pltfm_data = {
+-		.ops = &sdhci_cdns_ops,
++		.ops = &sdhci_cdns_sd6_ops,
+ 	},
++	.cdns_data = &sdhci_cdns_sd6_data,
+ };
+ 
+ static void sdhci_cdns_hs400_enhanced_strobe(struct mmc_host *mmc,
+@@ -475,6 +2345,51 @@ static void sdhci_cdns_mmc_hw_reset(struct mmc_host *mmc)
+ 	usleep_range(300, 1000);
+ }
+ 
++#ifdef CONFIG_DMI
++
++static char *part_no;
++#define DMI_ENTRY_PROCESSOR_MIN_LENGTH	48
++#define DMI_PROC_PART_NUMBER		0x22
++#define DMI_MAX_STRLEN			80
++
++static void find_proc_part(const struct dmi_header *dm, void *private)
++{
++	const u8 *dmi_data = (const u8 *)dm;
++	char *ptr;
++	int i, idx;
++
++	if (dm->type == DMI_ENTRY_PROCESSOR &&
++	    dm->length >= DMI_ENTRY_PROCESSOR_MIN_LENGTH) {
++		idx = (int)get_unaligned((const u8 *)
++					 (dmi_data + DMI_PROC_PART_NUMBER));
++		ptr = (char *)(dmi_data + dm->length);
++		for (i = 1; i < idx; i++) {
++			while (*ptr)
++				ptr++;
++			ptr++;
++		}
++		strscpy(private, ptr, DMI_MAX_STRLEN);
++	}
++}
++#endif
++
++static int dmi_check_part_no(void)
++{
++#ifdef CONFIG_DMI
++	part_no = kcalloc(DMI_MAX_STRLEN, sizeof(char), GFP_KERNEL);
++	if ((part_no) && !dmi_walk(find_proc_part, part_no)) {
++		if (!strncmp(part_no, "MV-CN10624-A", 12) ||
++		    !strncmp(part_no, "MV-CN10624SA", 12) ||
++		    !strncmp(part_no, "MV-CN10518-A", 12)) {
++			kfree(part_no);
++			return 1;
++		}
++		kfree(part_no);
++	}
++#endif
++	return 0;
++}
++
+ static int sdhci_cdns_probe(struct platform_device *pdev)
+ {
+ 	struct sdhci_host *host;
+@@ -483,31 +2398,46 @@ static int sdhci_cdns_probe(struct platform_device *pdev)
+ 	struct sdhci_cdns_priv *priv;
+ 	struct clk *clk;
+ 	unsigned int nr_phy_params;
++	bool has_acpi;
+ 	int ret;
+ 	struct device *dev = &pdev->dev;
+ 	static const u16 version = SDHCI_SPEC_400 << SDHCI_SPEC_VER_SHIFT;
+ 
+-	clk = devm_clk_get_enabled(dev, NULL);
+-	if (IS_ERR(clk))
+-		return PTR_ERR(clk);
++	has_acpi = has_acpi_companion(dev);
++
++	if (!has_acpi) {
++		clk = devm_clk_get_enabled(dev, NULL);
++		if (IS_ERR(clk))
++			return PTR_ERR(clk);
++	}
+ 
+-	data = of_device_get_match_data(dev);
+-	if (!data)
+-		data = &sdhci_cdns_drv_data;
++	data = device_get_match_data(dev);
++	if (!data) {
++		ret = PTR_ERR(data);
++		goto disable_clk;
++	}
+ 
+-	nr_phy_params = sdhci_cdns_phy_param_count(dev->of_node);
++	nr_phy_params = sdhci_cdns_sd4_phy_param_count(dev);
+ 	host = sdhci_pltfm_init(pdev, &data->pltfm_data,
+ 				struct_size(priv, phy_params, nr_phy_params));
+-	if (IS_ERR(host))
+-		return PTR_ERR(host);
++	if (IS_ERR(host)) {
++		ret = PTR_ERR(host);
++		goto disable_clk;
++	}
+ 
+ 	pltfm_host = sdhci_priv(host);
+-	pltfm_host->clk = clk;
++	if (!has_acpi)
++		pltfm_host->clk = clk;
+ 
++	host->clk_mul = 0;
++	host->max_clk = SDMCLK_MAX_FREQ;
++	host->quirks |=  SDHCI_QUIRK_CAP_CLOCK_BASE_BROKEN;
++	host->quirks2 |= SDHCI_QUIRK2_PRESET_VALUE_BROKEN;
+ 	priv = sdhci_pltfm_priv(pltfm_host);
+ 	priv->nr_phy_params = nr_phy_params;
+ 	priv->hrs_addr = host->ioaddr;
+ 	priv->enhanced_strobe = false;
++	priv->cdns_data = data->cdns_data;
+ 	priv->priv_writel = cdns_writel;
+ 	host->ioaddr += SDHCI_CDNS_SRS_BASE;
+ 	host->mmc_host_ops.hs400_enhanced_strobe =
+@@ -517,8 +2447,11 @@ static int sdhci_cdns_probe(struct platform_device *pdev)
+ 		if (ret)
+ 			goto free;
+ 	}
+-	sdhci_enable_v4_mode(host);
+-	__sdhci_read_caps(host, &version, NULL, NULL);
++
++	if (has_acpi)
++		cn10k_irq_workaround = dmi_check_part_no();
++	else if (is_soc_cn10ka_ax() || is_soc_cnf10ka_ax())
++		cn10k_irq_workaround = 1;
+ 
+ 	sdhci_get_of_property(pdev);
+ 
+@@ -526,12 +2459,19 @@ static int sdhci_cdns_probe(struct platform_device *pdev)
+ 	if (ret)
+ 		goto free;
+ 
+-	sdhci_cdns_phy_param_parse(dev->of_node, priv);
++	if (of_device_is_compatible(dev->of_node, "cdns,sd6hc")) {
++		ret = sdhci_cdns_sd6_phy_init(priv);
++	} else {
++		sdhci_cdns_sd4_phy_param_parse(dev, priv);
++		ret = sdhci_cdns_sd4_phy_init(priv);
++	}
+ 
+-	ret = sdhci_cdns_phy_init(priv);
+ 	if (ret)
+ 		goto free;
+ 
++	sdhci_enable_v4_mode(host);
++	__sdhci_read_caps(host, &version, NULL, NULL);
++
+ 	if (host->mmc->caps & MMC_CAP_HW_RESET) {
+ 		priv->rst_hw = devm_reset_control_get_optional_exclusive(dev, NULL);
+ 		if (IS_ERR(priv->rst_hw)) {
+@@ -550,6 +2490,10 @@ static int sdhci_cdns_probe(struct platform_device *pdev)
+ 	return 0;
+ free:
+ 	sdhci_pltfm_free(pdev);
++disable_clk:
++	if (!has_acpi)
++		clk_disable_unprepare(clk);
++
+ 	return ret;
+ }
+ 
+@@ -559,13 +2503,22 @@ static int sdhci_cdns_resume(struct device *dev)
+ 	struct sdhci_host *host = dev_get_drvdata(dev);
+ 	struct sdhci_pltfm_host *pltfm_host = sdhci_priv(host);
+ 	struct sdhci_cdns_priv *priv = sdhci_pltfm_priv(pltfm_host);
++	bool has_acpi;
+ 	int ret;
+ 
+-	ret = clk_prepare_enable(pltfm_host->clk);
+-	if (ret)
+-		return ret;
++	has_acpi = has_acpi_companion(dev);
++
++	if (!has_acpi) {
++		ret = clk_prepare_enable(pltfm_host->clk);
++		if (ret)
++			return ret;
++	}
++
++	if (priv->cdns_data->phy_init(priv))
++		ret = priv->cdns_data->phy_init(priv);
++	else
++		ret = sdhci_cdns_sd4_phy_init(priv);
+ 
+-	ret = sdhci_cdns_phy_init(priv);
+ 	if (ret)
+ 		goto disable_clk;
+ 
+@@ -576,7 +2529,8 @@ static int sdhci_cdns_resume(struct device *dev)
+ 	return 0;
+ 
+ disable_clk:
+-	clk_disable_unprepare(pltfm_host->clk);
++	if (!has_acpi)
++		clk_disable_unprepare(pltfm_host->clk);
+ 
+ 	return ret;
+ }
+@@ -595,7 +2549,14 @@ static const struct of_device_id sdhci_cdns_match[] = {
+ 		.compatible = "amd,pensando-elba-sd4hc",
+ 		.data = &sdhci_elba_drv_data,
+ 	},
+-	{ .compatible = "cdns,sd4hc" },
++	{
++		.compatible = "cdns,sd4hc",
++		.data = &sdhci_cdns_sd4_drv_data,
++	},
++	{
++		.compatible = "cdns,sd6hc",
++		.data = &sdhci_cdns_sd6_drv_data,
++	},
+ 	{ /* sentinel */ }
+ };
+ MODULE_DEVICE_TABLE(of, sdhci_cdns_match);
+diff --git a/drivers/net/ethernet/marvell/octeontx2/af/mbox.h b/drivers/net/ethernet/marvell/octeontx2/af/mbox.h
+index 6ea2f3071fe8..83aa6740d735 100644
+--- a/drivers/net/ethernet/marvell/octeontx2/af/mbox.h
++++ b/drivers/net/ethernet/marvell/octeontx2/af/mbox.h
+@@ -87,7 +87,7 @@ struct mbox_msghdr {
+ #define OTX2_MBOX_REQ_SIG (0xdead)
+ #define OTX2_MBOX_RSP_SIG (0xbeef)
+ 	u16 sig;         /* Signature, for validating corrupted msgs */
+-#define OTX2_MBOX_VERSION (0x000a)
++#define OTX2_MBOX_VERSION (0x000b)
+ 	u16 ver;         /* Version of msg's structure for this ID */
+ 	u16 next_msgoff; /* Offset of next msg within mailbox region */
+ 	int rc;          /* Msg process'ed response code */
+@@ -897,6 +897,7 @@ struct nix_lf_alloc_rsp {
+ 	u8	lf_tx_stats; /* NIX_AF_CONST1::LF_TX_STATS */
+ 	u16	cints; /* NIX_AF_CONST2::CINTS */
+ 	u16	qints; /* NIX_AF_CONST2::QINTS */
++	u8  hw_rx_tstamp_en;
+ 	u8	cgx_links;  /* No. of CGX links present in HW */
+ 	u8	lbk_links;  /* No. of LBK links present in HW */
+ 	u8	sdp_links;  /* No. of SDP links present in HW */
+diff --git a/include/linux/mmc/host.h b/include/linux/mmc/host.h
+index 8fc2b328ec4d..76f5d5a4ec9f 100644
+--- a/include/linux/mmc/host.h
++++ b/include/linux/mmc/host.h
+@@ -655,5 +655,7 @@ int mmc_send_status(struct mmc_card *card, u32 *status);
+ int mmc_send_tuning(struct mmc_host *host, u32 opcode, int *cmd_error);
+ int mmc_send_abort_tuning(struct mmc_host *host, u32 opcode);
+ int mmc_get_ext_csd(struct mmc_card *card, u8 **new_ext_csd);
++int mmc_read_tuning(struct mmc_host *host, unsigned int blksz,
++		    unsigned int blocks);
+ 
+ #endif /* LINUX_MMC_HOST_H */
+diff --git a/include/soc/marvell/octeontx/octeontx_smc.h b/include/soc/marvell/octeontx/octeontx_smc.h
+new file mode 100644
+index 000000000000..530a21981480
+--- /dev/null
++++ b/include/soc/marvell/octeontx/octeontx_smc.h
+@@ -0,0 +1,125 @@
++/* SPDX-License-Identifier: GPL-2.0 */
++
++/*
++ * Copyright (C) 2021 Marvell
++ *
++ */
++
++#ifndef _SOC_MRVL_OCTEONTX_SMC_H
++#define _SOC_MRVL_OCTEONTX_SMC_H
++
++#include <linux/errno.h>
++#include <linux/arm-smccc.h>
++#include <asm/cputype.h>
++#include <linux/of.h>
++#include <linux/sys_soc.h>
++
++/* Data and defines for SMC call */
++#define OCTEONTX_ARM_SMC_SVC_UID			0xc200ff01
++
++/* This is expected OCTEONTX response for SVC UID command */
++/** Check software version and compatibility of ATF
++ *
++ * The call verifies ATF instance running on the system.
++ *
++ * @return
++ *	0 (T9x) and 2 (cn10k) on success
++ *	error code on failure
++ *
++ */
++static inline int octeontx_soc_check_smc(void)
++{
++#define CPU_MODEL_CN10KX_PART	0xd49
++
++	const int octeontx_svc_uuid[] = {
++		0x6ff498cf,
++		0x5a4e9cfa,
++		0x2f2a3aa4,
++		0x5945b105,
++	};
++
++	struct arm_smccc_res res;
++
++	/* Is it OCTEONTX on the other side of SMC monitor? */
++	arm_smccc_smc(OCTEONTX_ARM_SMC_SVC_UID, 0, 0, 0, 0, 0, 0, 0, &res);
++	if (res.a0 != octeontx_svc_uuid[0] || res.a1 != octeontx_svc_uuid[1] ||
++	    res.a2 != octeontx_svc_uuid[2] || res.a3 != octeontx_svc_uuid[3])
++		return -EPERM;
++
++	if (MIDR_PARTNUM(read_cpuid_id()) == CPU_MODEL_CN10KX_PART)
++		return 2;
++
++	return 0;
++}
++
++static inline bool is_soc_cn9x(void)
++{
++	u32 partnum;
++
++	partnum = MIDR_PARTNUM(read_cpuid_id());
++
++	/* checking partnum between cn9xx and cn8xx series */
++	if (!((partnum & 0xF0) ^ (0xb0)) || !((partnum & 0xFF) ^ (0xaf)))
++		return true;
++
++	return false;
++}
++
++static inline bool is_soc_cn10kx(void)
++{
++	if (MIDR_PARTNUM(read_cpuid_id()) == CPU_MODEL_CN10KX_PART)
++		return 1;
++	return 0;
++}
++
++static inline bool is_soc_cnf10kb(void)
++{
++	static const struct soc_device_attribute cnf10kb_socinfo[] = {
++		{.soc_id = "jep106:0369:00bc", },
++		{},
++	};
++	const struct soc_device_attribute *attr;
++
++	attr = soc_device_match(cnf10kb_socinfo);
++
++	if (attr)
++		return true;
++
++	return false;
++}
++
++static inline bool is_soc_cn10ka_ax(void)
++{
++	static const struct soc_device_attribute cn10ka_socinfo[] = {
++		{.soc_id = "jep106:0369:00b9", .revision = "0x00000000", },
++		{.soc_id = "jep106:0369:00b9", .revision = "0x00000001", },
++		{},
++	};
++	const struct soc_device_attribute *attr;
++
++	attr = soc_device_match(cn10ka_socinfo);
++
++	if (attr)
++		return true;
++
++	return false;
++}
++
++static inline bool is_soc_cnf10ka_ax(void)
++{
++	static const struct soc_device_attribute cnf10ka_socinfo[] = {
++		{.soc_id = "jep106:0369:00ba", .revision = "0x00000000", },
++		{.soc_id = "jep106:0369:00ba", .revision = "0x00000001", },
++		{},
++	};
++	const struct soc_device_attribute *attr;
++
++	attr = soc_device_match(cnf10ka_socinfo);
++
++	if (attr)
++		return true;
++
++	return false;
++}
++
++#endif /* _SOC_MRVL_OCTEONTX_SMC_H */
+-- 
+2.43.0
+

--- a/patches-sonic/series
+++ b/patches-sonic/series
@@ -166,6 +166,9 @@ cisco-npu-disable-other-bars.patch
 0019-irqchip-mvebu-gicp-Clear-pending-interrupts-on-init.patch
 0022-arm64-dts-marvell-Add-DTS-for-cn9131-db-comexpress-trixie.patch
 
+# Marvell platform patches for 6.12 kernel
+0001-mmc-sdhci-cadence-Add-CN10K-eMMC-support.patch
+
 # amd-pensando elba support
 0001-Add-support-for-the-TI-TPS53659.patch
 0002-Adding-support-LTC3888.patch


### PR DESCRIPTION
What I did
-----------
Added support for Cadence Sdhci eMMC controller for octeon platform.

- This includes enabling the Cadence SD6 controller, HS400/HS400ES modes, 
   ACPI integration, PHY delay tuning, and multiple fixes for timing, tuning, and controller corner cases.
- Also updated the OTX2 mailbox interface version and related structures.

Why I did it
------------
Octeon platforms require specific controller handling and tuning for reliable
high-speed eMMC operation. Existing driver support lacked MMC
Controller-specific configurations, resulting in instability and incorrect
operation in HS400-class modes. Additionally, mailbox structure updates
were needed to align kernel and application interfaces

How I verified it
-----------------
- Booted Octeon platform with updated driver
- Verified eMMC enumeration and initialisation
- Tested HS400 / HS400ES mode transitions
- Validated tuning execution and value population
- Verified mailbox compatibility with updated structure

Details if related
------------------
- Added Cadence SD6 SDHCI controller support
- Enabled HS400 and HS400ES modes
- Configured PHY delays and default tuning values when DT values are missing or invalid
- Implemented delay element handling and Cadence-specific tuning logic, including multi-block read helpers
- Improved handling of DDR, clocking, enhanced strobe, command delay, block gap, and interrupt corner cases
- Added ACPI support for Octeon Cadence SDHCI instance
- Updated OTX2_MBOX_VERSION to 0x000b
- Extended struct nix_lf_alloc_rsp with hw_rx_tstamp_en

Patch upstreaming plan
----------------------

- These patches will not be upstreamed