### PR TITLE
Fix a bug in the Aspeed SPI driver to support full-duplex operations.

### DIFF
--- a/patches-sonic/aspeed-spi-txrx-fix-full-duplex-capture.patch
+++ b/patches-sonic/aspeed-spi-txrx-fix-full-duplex-capture.patch
@@ -1,0 +1,47 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Chandrasekaran Swaminathan <chander@nexthop.ai>
+Date: Thu, 2 Jul 2026 00:00:00 +0000
+Subject: [PATCH] spi: aspeed-txrx: capture full-duplex RX for distinct buffers
+
+The aspeed-txrx controller implements its own transfer_one_message and
+only latches MISO during the clocked TX loop when tx_buf == rx_buf (a
+single shared buffer). For any transfer that supplies separate tx_buf
+and rx_buf pointers it skipped the in-clock capture and instead issued a
+second, post-transfer ioread8_rep burst from the AHB window, which reads
+back zeros because the device has already returned its data.
+
+That shared-pointer requirement is not expressible through the standard
+spidev full-duplex ABI, which always hands the driver distinct bounce
+buffers. As a result userspace SPI_IOC_MESSAGE full-duplex reads (e.g.
+the FPGA register bridge) always returned zeros.
+
+Capture MISO during the TX loop whenever an rx buffer is present,
+regardless of pointer identity, and restrict the separate read burst to
+pure reads (no tx_buf). Behaviour is unchanged for write-only,
+read-only, and shared-buffer full-duplex (e.g. the TPM) transfers.
+
+Signed-off-by: Chandrasekaran Swaminathan <chander@nexthop.ai>
+---
+ drivers/spi/spi-aspeed-txrx.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/spi/spi-aspeed-txrx.c b/drivers/spi/spi-aspeed-txrx.c
+--- a/drivers/spi/spi-aspeed-txrx.c
++++ b/drivers/spi/spi-aspeed-txrx.c
+@@ -346,7 +346,7 @@ static void aspeed_spi_transfer_tx(struct aspeed_spi_host *host, const u8 *tx_buf,
+ 	for (i = 0; i < len; i++) {
+ 		writeb(tx_buf[i], dst);
+ 
+-		if (rx_buf && tx_buf == rx_buf)
++		if (rx_buf)
+ 			rx_buf[i] = readb(host->ctrl_reg + SPI_FULL_DUPLEX_RX_REG);
+ 	}
+ }
+@@ -407,6 +407,6 @@ static int aspeed_spi_transfer(struct spi_controller *ctlr,
+ 		}
+
+-		if (rx_buf && rx_buf != tx_buf) {
++		if (rx_buf && !tx_buf) {
+ 			ctrl_val &= ~SPI_IO_MASK;
+ 			if (spi->mode & SPI_RX_DUAL)
+ 				ctrl_val |= SPI_DUAL_IO_MODE;

--- a/patches-sonic/series
+++ b/patches-sonic/series
@@ -287,6 +287,7 @@ qsa-2026-apparmor/0011-apparmor-fix-race-between-freeing-data-and-fs-access.patc
 aspeed-ast2700-support.patch
 mmc-sdhci-of-aspeed-Improve-CMD6-timing_v6.18.patch
 mmc-sdhci-of-aspeed-Optimize-tuning-mechanism_v6.12.patch
+aspeed-spi-txrx-fix-full-duplex-capture.patch
 nexthop-b27-dts.patch
 0001-Add-device-tree-for-Nokia-BMC-H6-128-platform.patch
 arista_goldfinch-dts.patch


### PR DESCRIPTION
The aspeed-txrx controller only latched MISO during its TX loop when tx_buf == rx_buf, and otherwise issued a separate post-transfer ioread8_rep burst that returns zeros. spidev always hands the driver distinct tx/rx bounce buffers, so userspace SPI_IOC_MESSAGE full-duplex reads (e.g. the FPGA register bridge) always read back zeros.

Add patches-sonic/aspeed-spi-txrx-fix-full-duplex-capture.patch to capture RX during the TX loop whenever an rx buffer is present and restrict the separate read burst to pure reads, and register it in the series after aspeed-ast2700-support.patch. Behaviour is unchanged for write-only, read-only, and shared-buffer full-duplex (e.g. the TPM) transfers.

We have given this patch to Aspeed too and they have agreed to take it in their repository in a future release. Till that happens we will need this patch.